### PR TITLE
Fix rclone config keys for ProtonDrive setup

### DIFF
--- a/manual_configure.py
+++ b/manual_configure.py
@@ -41,8 +41,8 @@ def configure_protondrive():
         # Create config with interactive mode to handle 2FA properly
         config_cmd = [
             "rclone", "config", "create", "protondrive", "protondrive",
-            f"user={email}",
-            f"pass={obscured_pass}"
+            f"username={email}",
+            f"password={obscured_pass}"
         ]
         
         if twofa_code:


### PR DESCRIPTION
### **User description**
Replaces 'user' and 'pass' with 'username' and 'password' in the rclone config command to match expected parameter names for ProtonDrive.


___

### **PR Type**
Bug fix


___

### **Description**
- Corrects rclone config parameter names from `user`/`pass` to `username`/`password`

- Aligns with ProtonDrive's expected rclone configuration parameters

- Fixes configuration command to properly authenticate with ProtonDrive


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["rclone config command"] -->|"user/pass parameters"| B["Incorrect parameter names"]
  A -->|"username/password parameters"| C["Correct ProtonDrive config"]
  B -->|"Fix applied"| C
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>manual_configure.py</strong><dd><code>Update rclone parameter names for ProtonDrive</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

manual_configure.py

<ul><li>Replaced <code>user={email}</code> with <code>username={email}</code> in rclone config command<br> <li> Replaced <code>pass={obscured_pass}</code> with <code>password={obscured_pass}</code> in rclone <br>config command<br> <li> Fixed newline at end of file for proper formatting</ul>


</details>


  </td>
  <td><a href="https://github.com/DonnieDice/protondrive-linux/pull/10/files#diff-8824eaf507cf2e81956ccda9a09e5bd7c60a86b72365bb60ab83d3bb0abeedd2">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

