### PR TITLE
Implement Native 2-Way Live Sync with Recursive File Watching

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ This repository contains the source code for the Proton Drive Linux Desktop Clie
 *   **Full Authentication Support:** Login with username/password, 2FA (TOTP), and CAPTCHA verification all work in-app.
 *   **Native Desktop Experience:** Built with Tauri for seamless integration with your Linux desktop environment.
 *   **Downloads to ~/Downloads:** Files download directly to your Downloads folder.
+*   **Experimental Live 2-Way Sync Hooks:** Native commands are available to watch a local folder for changes and apply remote file updates into that same folder.
 *   **Multiple Distribution Formats:** Install via deb, rpm, AppImage, Snap, or Flatpak for compatibility with any Linux distribution.
 *   **Privacy-Focused:** Leverages Proton's commitment to privacy and end-to-end encryption.
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -26,6 +26,7 @@ reqwest = { version = "0.12", features = ["json", "cookies"] }
 base64 = "0.22"
 dirs = "5.0"
 mime_guess = "2.0"
+notify = "6.1"
 
 [features]
 default = ["custom-protocol"]

--- a/src-tauri/src/live_sync.rs
+++ b/src-tauri/src/live_sync.rs
@@ -1,0 +1,206 @@
+use notify::{Config, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+use std::fs;
+use std::path::{Component, Path, PathBuf};
+use std::sync::{mpsc, Arc, Mutex};
+use std::thread::JoinHandle;
+use tauri::{AppHandle, Emitter};
+
+#[derive(Debug, Clone, Serialize)]
+pub struct LiveSyncEvent {
+    pub kind: String,
+    pub paths: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct LiveSyncStatus {
+    pub enabled: bool,
+    pub folder_path: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RemoteSyncChange {
+    pub relative_path: String,
+    pub action: String, // create, update, delete
+    pub content_base64: Option<String>,
+}
+
+pub struct LiveSyncManager {
+    watcher: Mutex<Option<RecommendedWatcher>>,
+    folder: Mutex<Option<PathBuf>>,
+    worker: Mutex<Option<JoinHandle<()>>>,
+    known_files: Arc<Mutex<HashSet<PathBuf>>>,
+}
+
+impl Default for LiveSyncManager {
+    fn default() -> Self {
+        Self {
+            watcher: Mutex::new(None),
+            folder: Mutex::new(None),
+            worker: Mutex::new(None),
+            known_files: Arc::new(Mutex::new(HashSet::new())),
+        }
+    }
+}
+
+impl LiveSyncManager {
+    pub fn start(&self, app: AppHandle, folder: PathBuf) -> Result<(), String> {
+        if !folder.exists() || !folder.is_dir() {
+            return Err("Sync path must be a directory".into());
+        }
+
+        self.stop()?;
+
+        let (tx, rx) = mpsc::channel();
+        let mut watcher =
+            RecommendedWatcher::new(tx, Config::default()).map_err(|e| e.to_string())?;
+
+        watcher
+            .watch(&folder, RecursiveMode::Recursive)
+            .map_err(|e| e.to_string())?;
+
+        let known_files = Arc::clone(&self.known_files);
+        let app_handle = app.clone();
+
+        let worker = std::thread::Builder::new()
+            .name("live-sync-watcher".to_string())
+            .spawn(move || {
+                for res in rx {
+                    match res {
+                        Ok(event) => {
+                            let kind = match event.kind {
+                                EventKind::Create(_) => "create",
+                                EventKind::Modify(_) => "modify",
+                                EventKind::Remove(_) => "remove",
+                                _ => continue,
+                            };
+
+                            let mut filtered_paths = Vec::new();
+                            for path in event.paths {
+                                if should_ignore_known_file(&known_files, &path) {
+                                    continue;
+                                }
+                                filtered_paths.push(path.to_string_lossy().to_string());
+                            }
+
+                            if filtered_paths.is_empty() {
+                                continue;
+                            }
+
+                            let _ = app_handle.emit(
+                                "live-sync://local-change",
+                                LiveSyncEvent {
+                                    kind: kind.to_string(),
+                                    paths: filtered_paths,
+                                },
+                            );
+                        }
+                        Err(e) => eprintln!("[LiveSync] Watcher error: {e:?}"),
+                    }
+                }
+            })
+            .map_err(|e| format!("Failed to start watcher thread: {e}"))?;
+
+        *self.watcher.lock().map_err(|_| "Watcher lock poisoned")? = Some(watcher);
+        *self.folder.lock().map_err(|_| "Folder lock poisoned")? = Some(folder);
+        *self.worker.lock().map_err(|_| "Worker lock poisoned")? = Some(worker);
+
+        Ok(())
+    }
+
+    pub fn status(&self) -> Result<LiveSyncStatus, String> {
+        let folder = self.folder.lock().map_err(|_| "Folder lock poisoned")?;
+        Ok(LiveSyncStatus {
+            enabled: folder.is_some(),
+            folder_path: folder.as_ref().map(|p| p.to_string_lossy().to_string()),
+        })
+    }
+
+    pub fn apply_remote_change(&self, change: RemoteSyncChange) -> Result<String, String> {
+        let root = self
+            .folder
+            .lock()
+            .map_err(|_| "Folder lock poisoned")?
+            .clone()
+            .ok_or("Live sync is not active")?;
+
+        let relative = Path::new(&change.relative_path);
+        if relative.as_os_str().is_empty() {
+            return Err("Invalid relative path".into());
+        }
+        if relative.components().any(|c| {
+            matches!(
+                c,
+                Component::ParentDir | Component::RootDir | Component::Prefix(_)
+            )
+        }) {
+            return Err("Invalid relative path".into());
+        }
+
+        let target = root.join(relative);
+
+        match change.action.as_str() {
+            "create" | "update" => {
+                let encoded = change
+                    .content_base64
+                    .ok_or("contentBase64 is required for create/update")?;
+                let data = base64::decode(encoded).map_err(|e| e.to_string())?;
+
+                if let Some(parent) = target.parent() {
+                    fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+                }
+
+                self.mark_known_file(&target)?;
+                fs::write(&target, data).map_err(|e| e.to_string())?;
+            }
+            "delete" => {
+                if target.exists() {
+                    self.mark_known_file(&target)?;
+                    fs::remove_file(&target).map_err(|e| e.to_string())?;
+                }
+            }
+            _ => return Err("Unknown action".into()),
+        }
+
+        Ok(target.to_string_lossy().to_string())
+    }
+
+    pub fn stop(&self) -> Result<(), String> {
+        *self.watcher.lock().map_err(|_| "Watcher lock poisoned")? = None;
+        *self.folder.lock().map_err(|_| "Folder lock poisoned")? = None;
+
+        let worker = self
+            .worker
+            .lock()
+            .map_err(|_| "Worker lock poisoned")?
+            .take();
+        if let Some(worker) = worker {
+            let _ = worker.join();
+        }
+
+        self.known_files
+            .lock()
+            .map_err(|_| "Known files lock poisoned")?
+            .clear();
+
+        Ok(())
+    }
+
+    fn mark_known_file(&self, path: &Path) -> Result<(), String> {
+        self.known_files
+            .lock()
+            .map_err(|_| "Known files lock poisoned")?
+            .insert(path.to_path_buf());
+        Ok(())
+    }
+}
+
+fn should_ignore_known_file(known_files: &Arc<Mutex<HashSet<PathBuf>>>, path: &Path) -> bool {
+    if let Ok(mut cache) = known_files.lock() {
+        cache.remove(path)
+    } else {
+        false
+    }
+}

--- a/src-tauri/src/live_sync.rs
+++ b/src-tauri/src/live_sync.rs
@@ -8,6 +8,13 @@ use std::sync::{mpsc, Arc, Mutex};
 use std::thread::JoinHandle;
 use tauri::{AppHandle, Emitter};
 
+const ERR_SYNC_SETUP_FAILED: &str = "Failed to start live sync";
+const ERR_SYNC_STATE_UNAVAILABLE: &str = "Live sync is temporarily unavailable";
+const ERR_SYNC_NOT_ACTIVE: &str = "Live sync is not active";
+const ERR_SYNC_INVALID_REMOTE_CONTENT: &str = "Invalid remote file content";
+const ERR_SYNC_WRITE_FAILED: &str = "Failed to apply remote file update";
+const ERR_SYNC_DELETE_FAILED: &str = "Failed to apply remote file deletion";
+
 #[derive(Debug, Clone, Serialize)]
 pub struct LiveSyncEvent {
     pub kind: String,
@@ -55,12 +62,17 @@ impl LiveSyncManager {
         self.stop()?;
 
         let (tx, rx) = mpsc::channel();
-        let mut watcher =
-            RecommendedWatcher::new(tx, Config::default()).map_err(|e| e.to_string())?;
+        let mut watcher = RecommendedWatcher::new(tx, Config::default()).map_err(|e| {
+            eprintln!("[LiveSync] watcher init failed: {e}");
+            ERR_SYNC_SETUP_FAILED.to_string()
+        })?;
 
         watcher
             .watch(&folder, RecursiveMode::Recursive)
-            .map_err(|e| e.to_string())?;
+            .map_err(|e| {
+                eprintln!("[LiveSync] watcher start failed for {:?}: {e}", folder);
+                ERR_SYNC_SETUP_FAILED.to_string()
+            })?;
 
         let known_files = Arc::clone(&self.known_files);
         let app_handle = app.clone();
@@ -102,17 +114,32 @@ impl LiveSyncManager {
                     }
                 }
             })
-            .map_err(|e| format!("Failed to start watcher thread: {e}"))?;
+            .map_err(|e| {
+                eprintln!("[LiveSync] worker thread spawn failed: {e}");
+                ERR_SYNC_SETUP_FAILED.to_string()
+            })?;
 
-        *self.watcher.lock().map_err(|_| "Watcher lock poisoned")? = Some(watcher);
-        *self.folder.lock().map_err(|_| "Folder lock poisoned")? = Some(folder);
-        *self.worker.lock().map_err(|_| "Worker lock poisoned")? = Some(worker);
+        *self.watcher.lock().map_err(|e| {
+            eprintln!("[LiveSync] watcher state lock failed: {e}");
+            ERR_SYNC_STATE_UNAVAILABLE.to_string()
+        })? = Some(watcher);
+        *self.folder.lock().map_err(|e| {
+            eprintln!("[LiveSync] folder state lock failed: {e}");
+            ERR_SYNC_STATE_UNAVAILABLE.to_string()
+        })? = Some(folder);
+        *self.worker.lock().map_err(|e| {
+            eprintln!("[LiveSync] worker state lock failed: {e}");
+            ERR_SYNC_STATE_UNAVAILABLE.to_string()
+        })? = Some(worker);
 
         Ok(())
     }
 
     pub fn status(&self) -> Result<LiveSyncStatus, String> {
-        let folder = self.folder.lock().map_err(|_| "Folder lock poisoned")?;
+        let folder = self.folder.lock().map_err(|e| {
+            eprintln!("[LiveSync] status lock failed: {e}");
+            ERR_SYNC_STATE_UNAVAILABLE.to_string()
+        })?;
         Ok(LiveSyncStatus {
             enabled: folder.is_some(),
             folder_path: folder.as_ref().map(|p| p.to_string_lossy().to_string()),
@@ -123,9 +150,12 @@ impl LiveSyncManager {
         let root = self
             .folder
             .lock()
-            .map_err(|_| "Folder lock poisoned")?
+            .map_err(|e| {
+                eprintln!("[LiveSync] folder lock failed during remote apply: {e}");
+                ERR_SYNC_STATE_UNAVAILABLE.to_string()
+            })?
             .clone()
-            .ok_or("Live sync is not active")?;
+            .ok_or(ERR_SYNC_NOT_ACTIVE)?;
 
         let relative = Path::new(&change.relative_path);
         if relative.as_os_str().is_empty() {
@@ -149,19 +179,31 @@ impl LiveSyncManager {
                     .ok_or("contentBase64 is required for create/update")?;
                 let data = base64::engine::general_purpose::STANDARD
                     .decode(encoded)
-                    .map_err(|e| e.to_string())?;
+                    .map_err(|e| {
+                        eprintln!("[LiveSync] remote content decode failed: {e}");
+                        ERR_SYNC_INVALID_REMOTE_CONTENT.to_string()
+                    })?;
 
                 if let Some(parent) = target.parent() {
-                    fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+                    fs::create_dir_all(parent).map_err(|e| {
+                        eprintln!("[LiveSync] create parent dirs failed for {:?}: {e}", parent);
+                        ERR_SYNC_WRITE_FAILED.to_string()
+                    })?;
                 }
 
                 self.mark_known_file(&target)?;
-                fs::write(&target, data).map_err(|e| e.to_string())?;
+                fs::write(&target, data).map_err(|e| {
+                    eprintln!("[LiveSync] write failed for {:?}: {e}", target);
+                    ERR_SYNC_WRITE_FAILED.to_string()
+                })?;
             }
             "delete" => {
                 if target.exists() {
                     self.mark_known_file(&target)?;
-                    fs::remove_file(&target).map_err(|e| e.to_string())?;
+                    fs::remove_file(&target).map_err(|e| {
+                        eprintln!("[LiveSync] delete failed for {:?}: {e}", target);
+                        ERR_SYNC_DELETE_FAILED.to_string()
+                    })?;
                 }
             }
             _ => return Err("Unknown action".into()),
@@ -171,13 +213,22 @@ impl LiveSyncManager {
     }
 
     pub fn stop(&self) -> Result<(), String> {
-        *self.watcher.lock().map_err(|_| "Watcher lock poisoned")? = None;
-        *self.folder.lock().map_err(|_| "Folder lock poisoned")? = None;
+        *self.watcher.lock().map_err(|e| {
+            eprintln!("[LiveSync] watcher state lock failed on stop: {e}");
+            ERR_SYNC_STATE_UNAVAILABLE.to_string()
+        })? = None;
+        *self.folder.lock().map_err(|e| {
+            eprintln!("[LiveSync] folder state lock failed on stop: {e}");
+            ERR_SYNC_STATE_UNAVAILABLE.to_string()
+        })? = None;
 
         let worker = self
             .worker
             .lock()
-            .map_err(|_| "Worker lock poisoned")?
+            .map_err(|e| {
+                eprintln!("[LiveSync] worker state lock failed on stop: {e}");
+                ERR_SYNC_STATE_UNAVAILABLE.to_string()
+            })?
             .take();
         if let Some(worker) = worker {
             let _ = worker.join();
@@ -185,7 +236,10 @@ impl LiveSyncManager {
 
         self.known_files
             .lock()
-            .map_err(|_| "Known files lock poisoned")?
+            .map_err(|e| {
+                eprintln!("[LiveSync] known_files lock failed on stop: {e}");
+                ERR_SYNC_STATE_UNAVAILABLE.to_string()
+            })?
             .clear();
 
         Ok(())
@@ -194,7 +248,10 @@ impl LiveSyncManager {
     fn mark_known_file(&self, path: &Path) -> Result<(), String> {
         self.known_files
             .lock()
-            .map_err(|_| "Known files lock poisoned")?
+            .map_err(|e| {
+                eprintln!("[LiveSync] known_files lock failed on mark: {e}");
+                ERR_SYNC_STATE_UNAVAILABLE.to_string()
+            })?
             .insert(path.to_path_buf());
         Ok(())
     }

--- a/src-tauri/src/live_sync.rs
+++ b/src-tauri/src/live_sync.rs
@@ -14,6 +14,7 @@ const ERR_SYNC_NOT_ACTIVE: &str = "Live sync is not active";
 const ERR_SYNC_INVALID_REMOTE_CONTENT: &str = "Invalid remote file content";
 const ERR_SYNC_WRITE_FAILED: &str = "Failed to apply remote file update";
 const ERR_SYNC_DELETE_FAILED: &str = "Failed to apply remote file deletion";
+const ERR_SYNC_INVALID_TARGET: &str = "Invalid sync target path";
 
 #[derive(Debug, Clone, Serialize)]
 pub struct LiveSyncEvent {
@@ -31,13 +32,14 @@ pub struct LiveSyncStatus {
 #[serde(rename_all = "camelCase")]
 pub struct RemoteSyncChange {
     pub relative_path: String,
-    pub action: String, // create, update, delete
+    pub action: String,
     pub content_base64: Option<String>,
 }
 
 pub struct LiveSyncManager {
     watcher: Mutex<Option<RecommendedWatcher>>,
     folder: Mutex<Option<PathBuf>>,
+    root_canonical: Mutex<Option<PathBuf>>,
     worker: Mutex<Option<JoinHandle<()>>>,
     known_files: Arc<Mutex<HashSet<PathBuf>>>,
 }
@@ -47,6 +49,7 @@ impl Default for LiveSyncManager {
         Self {
             watcher: Mutex::new(None),
             folder: Mutex::new(None),
+            root_canonical: Mutex::new(None),
             worker: Mutex::new(None),
             known_files: Arc::new(Mutex::new(HashSet::new())),
         }
@@ -58,6 +61,11 @@ impl LiveSyncManager {
         if !folder.exists() || !folder.is_dir() {
             return Err("Sync path must be a directory".into());
         }
+
+        let canonical_root = folder.canonicalize().map_err(|e| {
+            eprintln!("[LiveSync] canonicalize root failed for {:?}: {e}", folder);
+            ERR_SYNC_SETUP_FAILED.to_string()
+        })?;
 
         self.stop()?;
 
@@ -110,7 +118,7 @@ impl LiveSyncManager {
                                 },
                             );
                         }
-                        Err(e) => eprintln!("[LiveSync] Watcher error: {e:?}"),
+                        Err(_) => eprintln!("[LiveSync] Watcher error occurred"),
                     }
                 }
             })
@@ -127,6 +135,10 @@ impl LiveSyncManager {
             eprintln!("[LiveSync] folder state lock failed: {e}");
             ERR_SYNC_STATE_UNAVAILABLE.to_string()
         })? = Some(folder);
+        *self.root_canonical.lock().map_err(|e| {
+            eprintln!("[LiveSync] root canonical state lock failed: {e}");
+            ERR_SYNC_STATE_UNAVAILABLE.to_string()
+        })? = Some(canonical_root);
         *self.worker.lock().map_err(|e| {
             eprintln!("[LiveSync] worker state lock failed: {e}");
             ERR_SYNC_STATE_UNAVAILABLE.to_string()
@@ -157,9 +169,19 @@ impl LiveSyncManager {
             .clone()
             .ok_or(ERR_SYNC_NOT_ACTIVE)?;
 
+        let canonical_root = self
+            .root_canonical
+            .lock()
+            .map_err(|e| {
+                eprintln!("[LiveSync] root canonical lock failed during remote apply: {e}");
+                ERR_SYNC_STATE_UNAVAILABLE.to_string()
+            })?
+            .clone()
+            .ok_or(ERR_SYNC_NOT_ACTIVE)?;
+
         let relative = Path::new(&change.relative_path);
         if relative.as_os_str().is_empty() {
-            return Err("Invalid relative path".into());
+            return Err(ERR_SYNC_INVALID_TARGET.into());
         }
         if relative.components().any(|c| {
             matches!(
@@ -167,7 +189,7 @@ impl LiveSyncManager {
                 Component::ParentDir | Component::RootDir | Component::Prefix(_)
             )
         }) {
-            return Err("Invalid relative path".into());
+            return Err(ERR_SYNC_INVALID_TARGET.into());
         }
 
         let target = root.join(relative);
@@ -176,7 +198,7 @@ impl LiveSyncManager {
             "create" | "update" => {
                 let encoded = change
                     .content_base64
-                    .ok_or("contentBase64 is required for create/update")?;
+                    .ok_or("Invalid remote update payload")?;
                 let data = base64::engine::general_purpose::STANDARD
                     .decode(encoded)
                     .map_err(|e| {
@@ -191,13 +213,34 @@ impl LiveSyncManager {
                     })?;
                 }
 
+                validate_path_within_root(&canonical_root, &target).map_err(|e| {
+                    eprintln!(
+                        "[LiveSync][AUDIT] rejected remote write action={} path={} reason={}",
+                        change.action, change.relative_path, e
+                    );
+                    ERR_SYNC_INVALID_TARGET.to_string()
+                })?;
+
                 self.mark_known_file(&target)?;
                 fs::write(&target, data).map_err(|e| {
                     eprintln!("[LiveSync] write failed for {:?}: {e}", target);
                     ERR_SYNC_WRITE_FAILED.to_string()
                 })?;
+
+                println!(
+                    "[LiveSync][AUDIT] remote action={} result=success path={}",
+                    change.action, change.relative_path
+                );
             }
             "delete" => {
+                validate_path_within_root(&canonical_root, &target).map_err(|e| {
+                    eprintln!(
+                        "[LiveSync][AUDIT] rejected remote delete path={} reason={}",
+                        change.relative_path, e
+                    );
+                    ERR_SYNC_INVALID_TARGET.to_string()
+                })?;
+
                 if target.exists() {
                     self.mark_known_file(&target)?;
                     fs::remove_file(&target).map_err(|e| {
@@ -205,6 +248,11 @@ impl LiveSyncManager {
                         ERR_SYNC_DELETE_FAILED.to_string()
                     })?;
                 }
+
+                println!(
+                    "[LiveSync][AUDIT] remote action=delete result=success path={}",
+                    change.relative_path
+                );
             }
             _ => return Err("Unknown action".into()),
         }
@@ -219,6 +267,10 @@ impl LiveSyncManager {
         })? = None;
         *self.folder.lock().map_err(|e| {
             eprintln!("[LiveSync] folder state lock failed on stop: {e}");
+            ERR_SYNC_STATE_UNAVAILABLE.to_string()
+        })? = None;
+        *self.root_canonical.lock().map_err(|e| {
+            eprintln!("[LiveSync] root canonical state lock failed on stop: {e}");
             ERR_SYNC_STATE_UNAVAILABLE.to_string()
         })? = None;
 
@@ -263,4 +315,50 @@ fn should_ignore_known_file(known_files: &Arc<Mutex<HashSet<PathBuf>>>, path: &P
     } else {
         false
     }
+}
+
+fn validate_path_within_root(root_canonical: &Path, target: &Path) -> Result<(), String> {
+    let mut cur = PathBuf::new();
+    for component in target.components() {
+        cur.push(component.as_os_str());
+        if let Ok(meta) = fs::symlink_metadata(&cur) {
+            if meta.file_type().is_symlink() {
+                return Err("symlink traversal is not allowed".to_string());
+            }
+        }
+    }
+
+    let canonical_target = if target.exists() {
+        target
+            .canonicalize()
+            .map_err(|_| "unable to resolve target path".to_string())?
+    } else {
+        let existing_ancestor = find_existing_ancestor(target)
+            .ok_or_else(|| "target has no existing ancestor".to_string())?;
+        let canonical_ancestor = existing_ancestor
+            .canonicalize()
+            .map_err(|_| "unable to resolve ancestor path".to_string())?;
+
+        if !canonical_ancestor.starts_with(root_canonical) {
+            return Err("target escapes sync root".to_string());
+        }
+
+        return Ok(());
+    };
+
+    if !canonical_target.starts_with(root_canonical) {
+        return Err("target escapes sync root".to_string());
+    }
+
+    Ok(())
+}
+
+fn find_existing_ancestor(path: &Path) -> Option<PathBuf> {
+    let mut current = path.to_path_buf();
+    while !current.exists() {
+        if !current.pop() {
+            return None;
+        }
+    }
+    Some(current)
 }

--- a/src-tauri/src/live_sync.rs
+++ b/src-tauri/src/live_sync.rs
@@ -1,3 +1,4 @@
+use base64::Engine as _;
 use notify::{Config, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
@@ -146,7 +147,9 @@ impl LiveSyncManager {
                 let encoded = change
                     .content_base64
                     .ok_or("contentBase64 is required for create/update")?;
-                let data = base64::decode(encoded).map_err(|e| e.to_string())?;
+                let data = base64::engine::general_purpose::STANDARD
+                    .decode(encoded)
+                    .map_err(|e| e.to_string())?;
 
                 if let Some(parent) = target.parent() {
                     fs::create_dir_all(parent).map_err(|e| e.to_string())?;

--- a/src-tauri/src/live_sync.rs
+++ b/src-tauri/src/live_sync.rs
@@ -1,11 +1,12 @@
 use base64::Engine as _;
 use notify::{Config, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
 use serde::{Deserialize, Serialize};
-use std::collections::HashSet;
+use std::collections::HashMap;
 use std::fs;
 use std::path::{Component, Path, PathBuf};
 use std::sync::{mpsc, Arc, Mutex};
 use std::thread::JoinHandle;
+use std::time::{Duration, Instant};
 use tauri::{AppHandle, Emitter};
 
 const ERR_SYNC_SETUP_FAILED: &str = "Failed to start live sync";
@@ -15,6 +16,8 @@ const ERR_SYNC_INVALID_REMOTE_CONTENT: &str = "Invalid remote file content";
 const ERR_SYNC_WRITE_FAILED: &str = "Failed to apply remote file update";
 const ERR_SYNC_DELETE_FAILED: &str = "Failed to apply remote file deletion";
 const ERR_SYNC_INVALID_TARGET: &str = "Invalid sync target path";
+const SUPPRESSION_TTL: Duration = Duration::from_secs(30);
+const SUPPRESSION_CACHE_MAX: usize = 4096;
 
 #[derive(Debug, Clone, Serialize)]
 pub struct LiveSyncEvent {
@@ -41,7 +44,7 @@ pub struct LiveSyncManager {
     folder: Mutex<Option<PathBuf>>,
     root_canonical: Mutex<Option<PathBuf>>,
     worker: Mutex<Option<JoinHandle<()>>>,
-    known_files: Arc<Mutex<HashSet<PathBuf>>>,
+    known_files: Arc<Mutex<HashMap<PathBuf, Instant>>>,
 }
 
 impl Default for LiveSyncManager {
@@ -51,7 +54,7 @@ impl Default for LiveSyncManager {
             folder: Mutex::new(None),
             root_canonical: Mutex::new(None),
             worker: Mutex::new(None),
-            known_files: Arc::new(Mutex::new(HashSet::new())),
+            known_files: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 }
@@ -110,13 +113,15 @@ impl LiveSyncManager {
                                 continue;
                             }
 
-                            let _ = app_handle.emit(
+                            if let Err(e) = app_handle.emit(
                                 "live-sync://local-change",
                                 LiveSyncEvent {
                                     kind: kind.to_string(),
                                     paths: filtered_paths,
                                 },
-                            );
+                            ) {
+                                eprintln!("[LiveSync] failed to emit local-change event: {e}");
+                            }
                         }
                         Err(_) => eprintln!("[LiveSync] Watcher error occurred"),
                     }
@@ -206,13 +211,6 @@ impl LiveSyncManager {
                         ERR_SYNC_INVALID_REMOTE_CONTENT.to_string()
                     })?;
 
-                if let Some(parent) = target.parent() {
-                    fs::create_dir_all(parent).map_err(|e| {
-                        eprintln!("[LiveSync] create parent dirs failed for {:?}: {e}", parent);
-                        ERR_SYNC_WRITE_FAILED.to_string()
-                    })?;
-                }
-
                 validate_path_within_root(&canonical_root, &target).map_err(|e| {
                     eprintln!(
                         "[LiveSync][AUDIT] rejected remote write action={} path={} reason={}",
@@ -220,6 +218,13 @@ impl LiveSyncManager {
                     );
                     ERR_SYNC_INVALID_TARGET.to_string()
                 })?;
+
+                if let Some(parent) = target.parent() {
+                    fs::create_dir_all(parent).map_err(|e| {
+                        eprintln!("[LiveSync] create parent dirs failed for {:?}: {e}", parent);
+                        ERR_SYNC_WRITE_FAILED.to_string()
+                    })?;
+                }
 
                 self.mark_known_file(&target)?;
                 fs::write(&target, data).map_err(|e| {
@@ -298,22 +303,42 @@ impl LiveSyncManager {
     }
 
     fn mark_known_file(&self, path: &Path) -> Result<(), String> {
-        self.known_files
-            .lock()
-            .map_err(|e| {
-                eprintln!("[LiveSync] known_files lock failed on mark: {e}");
-                ERR_SYNC_STATE_UNAVAILABLE.to_string()
-            })?
-            .insert(path.to_path_buf());
+        let mut cache = self.known_files.lock().map_err(|e| {
+            eprintln!("[LiveSync] known_files lock failed on mark: {e}");
+            ERR_SYNC_STATE_UNAVAILABLE.to_string()
+        })?;
+        let now = Instant::now();
+        prune_known_files(&mut cache, now);
+        cache.insert(path.to_path_buf(), now);
         Ok(())
     }
 }
 
-fn should_ignore_known_file(known_files: &Arc<Mutex<HashSet<PathBuf>>>, path: &Path) -> bool {
+fn should_ignore_known_file(known_files: &Arc<Mutex<HashMap<PathBuf, Instant>>>, path: &Path) -> bool {
     if let Ok(mut cache) = known_files.lock() {
-        cache.remove(path)
+        let now = Instant::now();
+        prune_known_files(&mut cache, now);
+        if let Some(marked_at) = cache.remove(path) {
+            return now.saturating_duration_since(marked_at) <= SUPPRESSION_TTL;
+        }
+        false
     } else {
         false
+    }
+}
+
+fn prune_known_files(cache: &mut HashMap<PathBuf, Instant>, now: Instant) {
+    cache.retain(|_, marked_at| now.saturating_duration_since(*marked_at) <= SUPPRESSION_TTL);
+    if cache.len() <= SUPPRESSION_CACHE_MAX {
+        return;
+    }
+
+    // If burst volume still exceeds cap, drop oldest markers first.
+    let mut by_age: Vec<(PathBuf, Instant)> = cache.iter().map(|(p, t)| (p.clone(), *t)).collect();
+    by_age.sort_by_key(|(_, t)| *t);
+    let overflow = by_age.len() - SUPPRESSION_CACHE_MAX;
+    for (path, _) in by_age.into_iter().take(overflow) {
+        cache.remove(&path);
     }
 }
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -97,12 +97,14 @@ async fn navigate_to_captcha(
 
     // Navigate main window to captcha (local or external)
     if let Some(window) = app.get_webview_window("main") {
-        let url: tauri::Url = captcha_url
-            .parse()
-            .map_err(|e| format!("Invalid URL: {}", e))?;
-        window
-            .navigate(url)
-            .map_err(|e| format!("Navigation failed: {}", e))?;
+        let url: tauri::Url = captcha_url.parse().map_err(|e| {
+            eprintln!("[CAPTCHA] Invalid captcha URL '{}': {e}", captcha_url);
+            "Unable to open verification page".to_string()
+        })?;
+        window.navigate(url).map_err(|e| {
+            eprintln!("[CAPTCHA] Navigation to captcha failed: {e}");
+            "Unable to open verification page".to_string()
+        })?;
     }
 
     Ok(())
@@ -117,16 +119,24 @@ fn get_captcha_return_url() -> Option<String> {
 async fn save_download(filename: String, data: Vec<u8>) -> Result<String, String> {
     let downloads_dir = dirs::download_dir()
         .or_else(|| dirs::home_dir().map(|h| h.join("Downloads")))
-        .ok_or("Could not find Downloads directory")?;
+        .ok_or("Unable to access download location")?;
 
     // Ensure downloads dir exists
-    std::fs::create_dir_all(&downloads_dir)
-        .map_err(|e| format!("Failed to create Downloads dir: {}", e))?;
+    std::fs::create_dir_all(&downloads_dir).map_err(|e| {
+        eprintln!(
+            "[Download] Failed to create downloads dir {:?}: {e}",
+            downloads_dir
+        );
+        "Unable to save download".to_string()
+    })?;
 
     let file_path = downloads_dir.join(&filename);
     println!("[Download] Saving to: {:?}", file_path);
 
-    std::fs::write(&file_path, &data).map_err(|e| format!("Failed to write file: {}", e))?;
+    std::fs::write(&file_path, &data).map_err(|e| {
+        eprintln!("[Download] Failed to write download {:?}: {e}", file_path);
+        "Unable to save download".to_string()
+    })?;
 
     Ok(file_path.to_string_lossy().to_string())
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -3,17 +3,20 @@
     windows_subsystem = "windows"
 )]
 
-use std::collections::HashMap;
-use std::sync::Arc;
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::sync::Arc;
 use tauri::{Manager, WebviewUrl, WebviewWindowBuilder};
+
+mod live_sync;
 
 const PROTON_API_BASE: &str = "https://mail.proton.me";
 
 // Shared HTTP client with cookie jar
 struct AppState {
     client: Client,
+    sync_manager: live_sync::LiveSyncManager,
 }
 
 #[derive(Debug, Deserialize)]
@@ -43,10 +46,12 @@ static CAPTCHA_RETURN_URL: std::sync::Mutex<Option<String>> = std::sync::Mutex::
 static ON_CAPTCHA_PAGE: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
 
 // Store verification token in memory only (zero trust - cleared after use)
-static PENDING_VERIFICATION: std::sync::Mutex<Option<(String, String)>> = std::sync::Mutex::new(None);
+static PENDING_VERIFICATION: std::sync::Mutex<Option<(String, String)>> =
+    std::sync::Mutex::new(None);
 
 // Store login credentials during captcha flow (zero trust - cleared after use)
-static PENDING_CREDENTIALS: std::sync::Mutex<Option<(String, String)>> = std::sync::Mutex::new(None);
+static PENDING_CREDENTIALS: std::sync::Mutex<Option<(String, String)>> =
+    std::sync::Mutex::new(None);
 
 #[tauri::command]
 fn store_verification_token(token: String, token_type: String) {
@@ -79,7 +84,11 @@ fn get_and_clear_login_credentials() -> Option<(String, String)> {
 }
 
 #[tauri::command]
-async fn navigate_to_captcha(app: tauri::AppHandle, captcha_url: String, return_url: String) -> Result<(), String> {
+async fn navigate_to_captcha(
+    app: tauri::AppHandle,
+    captcha_url: String,
+    return_url: String,
+) -> Result<(), String> {
     println!("[CAPTCHA] Navigating main window to: {}", captcha_url);
     println!("[CAPTCHA] Will return to: {}", return_url);
 
@@ -88,8 +97,12 @@ async fn navigate_to_captcha(app: tauri::AppHandle, captcha_url: String, return_
 
     // Navigate main window to captcha (local or external)
     if let Some(window) = app.get_webview_window("main") {
-        let url: tauri::Url = captcha_url.parse().map_err(|e| format!("Invalid URL: {}", e))?;
-        window.navigate(url).map_err(|e| format!("Navigation failed: {}", e))?;
+        let url: tauri::Url = captcha_url
+            .parse()
+            .map_err(|e| format!("Invalid URL: {}", e))?;
+        window
+            .navigate(url)
+            .map_err(|e| format!("Navigation failed: {}", e))?;
     }
 
     Ok(())
@@ -113,10 +126,42 @@ async fn save_download(filename: String, data: Vec<u8>) -> Result<String, String
     let file_path = downloads_dir.join(&filename);
     println!("[Download] Saving to: {:?}", file_path);
 
-    std::fs::write(&file_path, &data)
-        .map_err(|e| format!("Failed to write file: {}", e))?;
+    std::fs::write(&file_path, &data).map_err(|e| format!("Failed to write file: {}", e))?;
 
     Ok(file_path.to_string_lossy().to_string())
+}
+
+#[tauri::command]
+fn start_sync(
+    app: tauri::AppHandle,
+    state: tauri::State<'_, Arc<AppState>>,
+    path: String,
+) -> Result<live_sync::LiveSyncStatus, String> {
+    state
+        .sync_manager
+        .start(app, std::path::PathBuf::from(path))?;
+    state.sync_manager.status()
+}
+
+#[tauri::command]
+fn stop_sync(state: tauri::State<'_, Arc<AppState>>) -> Result<live_sync::LiveSyncStatus, String> {
+    state.sync_manager.stop()?;
+    state.sync_manager.status()
+}
+
+#[tauri::command]
+fn get_sync_status(
+    state: tauri::State<'_, Arc<AppState>>,
+) -> Result<live_sync::LiveSyncStatus, String> {
+    state.sync_manager.status()
+}
+
+#[tauri::command]
+fn handle_remote_update(
+    state: tauri::State<'_, Arc<AppState>>,
+    change: live_sync::RemoteSyncChange,
+) -> Result<String, String> {
+    state.sync_manager.apply_remote_change(change)
 }
 
 #[tauri::command]
@@ -125,9 +170,15 @@ async fn proxy_request(
     request: ProxyRequest,
 ) -> Result<ProxyResponse, String> {
     // Build the target URL - extract path from various URL formats
-    let url = if request.url.starts_with("https://localhost/api/") || request.url.starts_with("http://localhost/api/") {
+    let url = if request.url.starts_with("https://localhost/api/")
+        || request.url.starts_with("http://localhost/api/")
+    {
         // Rewrite localhost API calls to Proton
-        format!("{}{}", PROTON_API_BASE, &request.url[request.url.find("/api").unwrap()..])
+        format!(
+            "{}{}",
+            PROTON_API_BASE,
+            &request.url[request.url.find("/api").unwrap()..]
+        )
     } else if request.url.starts_with("https://") || request.url.starts_with("http://") {
         request.url.clone()
     } else if request.url.starts_with("tauri://") {
@@ -163,7 +214,10 @@ async fn proxy_request(
         req = req.body(body.clone());
     }
 
-    let resp = req.send().await.map_err(|e| format!("Request failed: {}", e))?;
+    let resp = req
+        .send()
+        .await
+        .map_err(|e| format!("Request failed: {}", e))?;
     let status = resp.status().as_u16();
 
     // Forward response headers including set-cookie (needed for WebView session)
@@ -190,7 +244,11 @@ async fn proxy_request(
         println!("[Proxy] Body: {}", body);
     }
 
-    Ok(ProxyResponse { status, headers: resp_headers, body })
+    Ok(ProxyResponse {
+        status,
+        headers: resp_headers,
+        body,
+    })
 }
 
 fn main() {
@@ -204,9 +262,10 @@ fn main() {
     // Create shared client with cookie jar
     let state = Arc::new(AppState {
         client: Client::builder()
-            .cookie_store(true)  // Enable cookie jar
+            .cookie_store(true) // Enable cookie jar
             .build()
             .expect("Failed to create HTTP client"),
+        sync_manager: live_sync::LiveSyncManager::default(),
     });
 
     tauri::Builder::default()
@@ -1021,7 +1080,7 @@ fn main() {
 
             Ok(())
         })
-        .invoke_handler(tauri::generate_handler![proxy_request, js_log, navigate_to_captcha, get_captcha_return_url, store_verification_token, get_and_clear_verification_token, store_login_credentials, get_and_clear_login_credentials, save_download])
+        .invoke_handler(tauri::generate_handler![proxy_request, js_log, navigate_to_captcha, get_captcha_return_url, store_verification_token, get_and_clear_verification_token, store_login_credentials, get_and_clear_login_credentials, save_download, start_sync, stop_sync, get_sync_status, handle_remote_update])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -6,12 +6,14 @@
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::path::PathBuf;
 use std::sync::Arc;
 use tauri::{Manager, WebviewUrl, WebviewWindowBuilder};
 
 mod live_sync;
 
 const PROTON_API_BASE: &str = "https://mail.proton.me";
+const ERR_SYNC_NOT_ALLOWED: &str = "Sync operation is not allowed in this context";
 
 // Shared HTTP client with cookie jar
 struct AppState {
@@ -89,8 +91,7 @@ async fn navigate_to_captcha(
     captcha_url: String,
     return_url: String,
 ) -> Result<(), String> {
-    println!("[CAPTCHA] Navigating main window to: {}", captcha_url);
-    println!("[CAPTCHA] Will return to: {}", return_url);
+    println!("[CAPTCHA] Starting verification navigation flow");
 
     // Store return URL
     *CAPTCHA_RETURN_URL.lock().unwrap() = Some(return_url);
@@ -131,7 +132,7 @@ async fn save_download(filename: String, data: Vec<u8>) -> Result<String, String
     })?;
 
     let file_path = downloads_dir.join(&filename);
-    println!("[Download] Saving to: {:?}", file_path);
+    println!("[Download] Saving file to Downloads folder");
 
     std::fs::write(&file_path, &data).map_err(|e| {
         eprintln!("[Download] Failed to write download {:?}: {e}", file_path);
@@ -143,34 +144,43 @@ async fn save_download(filename: String, data: Vec<u8>) -> Result<String, String
 
 #[tauri::command]
 fn start_sync(
+    window: tauri::WebviewWindow,
     app: tauri::AppHandle,
     state: tauri::State<'_, Arc<AppState>>,
     path: String,
 ) -> Result<live_sync::LiveSyncStatus, String> {
-    state
-        .sync_manager
-        .start(app, std::path::PathBuf::from(path))?;
+    ensure_sync_command_allowed(&window)?;
+    let sync_root = validate_sync_root_path(&path)?;
+    state.sync_manager.start(app, sync_root)?;
     state.sync_manager.status()
 }
 
 #[tauri::command]
-fn stop_sync(state: tauri::State<'_, Arc<AppState>>) -> Result<live_sync::LiveSyncStatus, String> {
+fn stop_sync(
+    window: tauri::WebviewWindow,
+    state: tauri::State<'_, Arc<AppState>>,
+) -> Result<live_sync::LiveSyncStatus, String> {
+    ensure_sync_command_allowed(&window)?;
     state.sync_manager.stop()?;
     state.sync_manager.status()
 }
 
 #[tauri::command]
 fn get_sync_status(
+    window: tauri::WebviewWindow,
     state: tauri::State<'_, Arc<AppState>>,
 ) -> Result<live_sync::LiveSyncStatus, String> {
+    ensure_sync_command_allowed(&window)?;
     state.sync_manager.status()
 }
 
 #[tauri::command]
 fn handle_remote_update(
+    window: tauri::WebviewWindow,
     state: tauri::State<'_, Arc<AppState>>,
     change: live_sync::RemoteSyncChange,
 ) -> Result<String, String> {
+    ensure_sync_command_allowed(&window)?;
     state.sync_manager.apply_remote_change(change)
 }
 
@@ -207,7 +217,7 @@ async fn proxy_request(
     let method = reqwest::Method::from_bytes(request.method.to_uppercase().as_bytes())
         .unwrap_or(reqwest::Method::GET);
 
-    println!("[Proxy] {} {}", method, url);
+    println!("[Proxy] {} {}", method, sanitize_url_for_log(&url));
 
     let mut req = state.client.request(method, &url);
 
@@ -224,10 +234,13 @@ async fn proxy_request(
         req = req.body(body.clone());
     }
 
-    let resp = req
-        .send()
-        .await
-        .map_err(|e| format!("Request failed: {}", e))?;
+    let resp = req.send().await.map_err(|e| {
+        eprintln!(
+            "[Proxy] request failed for {}: {e}",
+            sanitize_url_for_log(&url)
+        );
+        "Request failed".to_string()
+    })?;
     let status = resp.status().as_u16();
 
     // Forward response headers including set-cookie (needed for WebView session)
@@ -249,16 +262,61 @@ async fn proxy_request(
 
     let body = resp.text().await.unwrap_or_default();
 
-    println!("[Proxy] {} <- {}", status, url);
-    if body.len() < 500 {
-        println!("[Proxy] Body: {}", body);
-    }
+    println!("[Proxy] {} <- {}", status, sanitize_url_for_log(&url));
 
     Ok(ProxyResponse {
         status,
         headers: resp_headers,
         body,
     })
+}
+
+fn ensure_sync_command_allowed(window: &tauri::WebviewWindow) -> Result<(), String> {
+    let current_url = window.url().map_err(|e| {
+        eprintln!("[Sync] failed to read window URL: {e}");
+        ERR_SYNC_NOT_ALLOWED.to_string()
+    })?;
+
+    let host = current_url.host_str().unwrap_or_default();
+    let is_allowed =
+        current_url.scheme() == "tauri" && (host == "localhost" || host == "tauri.localhost");
+
+    if !is_allowed {
+        eprintln!(
+            "[Sync] rejected command from origin scheme={} host={}",
+            current_url.scheme(),
+            host
+        );
+        return Err(ERR_SYNC_NOT_ALLOWED.to_string());
+    }
+
+    Ok(())
+}
+
+fn validate_sync_root_path(path: &str) -> Result<PathBuf, String> {
+    let canonical = PathBuf::from(path).canonicalize().map_err(|e| {
+        eprintln!("[Sync] invalid sync root path '{}': {e}", path);
+        "Invalid sync folder".to_string()
+    })?;
+
+    let home = dirs::home_dir().ok_or("Invalid sync folder")?;
+    if !canonical.starts_with(&home) {
+        eprintln!(
+            "[Sync] rejected sync root outside home: path={:?} home={:?}",
+            canonical, home
+        );
+        return Err("Invalid sync folder".to_string());
+    }
+
+    Ok(canonical)
+}
+
+fn sanitize_url_for_log(url: &str) -> String {
+    if let Ok(parsed) = tauri::Url::parse(url) {
+        let host = parsed.host_str().unwrap_or("unknown");
+        return format!("{}://{}{}", parsed.scheme(), host, parsed.path());
+    }
+    "<unparsed-url>".to_string()
 }
 
 fn main() {

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1080,7 +1080,21 @@ fn main() {
 
             Ok(())
         })
-        .invoke_handler(tauri::generate_handler![proxy_request, js_log, navigate_to_captcha, get_captcha_return_url, store_verification_token, get_and_clear_verification_token, store_login_credentials, get_and_clear_login_credentials, save_download, start_sync, stop_sync, get_sync_status, handle_remote_update])
+        .invoke_handler(tauri::generate_handler![
+            proxy_request,
+            js_log,
+            navigate_to_captcha,
+            get_captcha_return_url,
+            store_verification_token,
+            get_and_clear_verification_token,
+            store_login_credentials,
+            get_and_clear_login_credentials,
+            save_download,
+            start_sync,
+            stop_sync,
+            get_sync_status,
+            handle_remote_update
+        ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }


### PR DESCRIPTION
# PR: Harden live 2-way sync: path safety, bounded suppression cache, and safer logging

## Summary

This updates the experimental native 2-way sync implementation with security and reliability hardening, while preserving the same cross-package behavior (AUR/AppImage/Flatpak/snap/deb/rpm).

## What changed

### 1) Remote write safety: validate before mutation
- For `create`/`update`, target path validation now executes **before** any directory/file mutation.
- This prevents side effects before rejection when a path fails root/symlink safety checks.

### 2) Bounded ping-pong suppression cache
- Replaced unbounded suppression tracking with a bounded + expiring cache.
- Added:
  - TTL-based expiration
  - size cap with oldest-entry eviction
- Prevents long-running sessions from accumulating stale suppression entries.

### 3) Event emission reliability
- `emit("live-sync://local-change", ...)` failures are now logged explicitly.
- Avoids silent sync-signal loss.

### 4) Existing hardening included
- Generic/sanitized user-facing error strings.
- Added remote write/delete audit logs.
- Added sync command origin checks and root-path constraints.
- Added `notify` dependency for native recursive watcher.

## Files changed

- `src-tauri/src/live_sync.rs`
- `src-tauri/src/main.rs`
- `src-tauri/Cargo.toml`
- `README.md`

## Why

This addresses reviewer concerns around:
- path traversal / symlink escape risk
- unbounded suppression state growth
- silent event propagation failures
- sensitive error/log exposure

## Notes

- No package-specific runtime code paths were introduced.
- Changes stay in shared app logic and remain package-format agnostic.
- I could not run `cargo check` in my current shell because Rust/Cargo is not installed there.
"@

$bodyFile = Join-Path $PWD "pr-body.md"
Set-Content -Path $bodyFile -Value $prBody -Encoding UTF8
