### PR TITLE
Replace AUR AppImage-wrapper with native Arch build

### DIFF
--- a/.github/workflows/build-aur.yml
+++ b/.github/workflows/build-aur.yml
@@ -1,4 +1,4 @@
-name: Build AUR
+name: Build AUR Arch Native
 
 "on":
   push:

--- a/.github/workflows/build-aur.yml
+++ b/.github/workflows/build-aur.yml
@@ -3,150 +3,141 @@ name: Build AUR
 "on":
   push:
     branches:
-      - main
-      - dev
-      - alpha
+    - main
+    - dev
+    - alpha
     tags:
-      - "v*"
+    - "v*"
   workflow_dispatch:
-    inputs:
-      aur_target:
-        description: AUR target (arch)
-        required: false
-        default: arch
 
 permissions:
- contents: read
+  contents: read
 
 env:
- RUST_VERSION: stable
+  RUST_VERSION: stable
 
 jobs:
- build-aur:
-   name: AUR ${{ github.event.inputs.aur_target || 'arch' }}
-   runs-on: ubuntu-latest
-   container:
-     image: archlinux:base-devel
-   timeout-minutes: 120
-   defaults:
-     run:
-       shell: bash
+  build-aur:
+    name: AUR Arch Native
+    runs-on: ubuntu-latest
+    container:
+      image: archlinux:base-devel
+    timeout-minutes: 120
+    defaults:
+      run:
+        shell: bash
 
-   steps:
-   - name: Install build dependencies
-     run: |
-       pacman -Sy --noconfirm --needed bash git curl wget file pkg-config webkit2gtk-4.1 gtk3 libayatana-appindicator openssl librsvg libsoup3 nodejs npm python rustup base-devel patchelf
+    steps:
+    - name: Install build dependencies
+      run: |
+        pacman -Sy --noconfirm --needed bash git curl wget file pkg-config webkit2gtk-4.1 gtk3 libayatana-appindicator openssl librsvg libsoup3 nodejs npm python rustup base-devel patch
 
-   - name: Install Rust
-     run: |
-       rustup default "${RUST_VERSION}"
-       rustc --version
-       cargo --version
+    - name: Install Rust
+      run: |
+        rustup default "${RUST_VERSION}"
+        rustc --version
+        cargo --version
 
-   - name: Checkout repository
-     uses: actions/checkout@v4
+    - name: Checkout repository
+      uses: actions/checkout@v4
 
-   - name: Cache Cargo
-     uses: actions/cache@v4
-     with:
-       path: |
-         ~/.cargo/bin/
-         ~/.cargo/registry/index/
-         ~/.cargo/registry/cache/
-         ~/.cargo/git/db/
-         src-tauri/target/
-       key: aur-${{ github.event.inputs.aur_target || 'arch' }}-cargo-${{ hashFiles('src-tauri/Cargo.lock') }}
-       restore-keys: aur-${{ github.event.inputs.aur_target || 'arch' }}-cargo-
+    - name: Cache Cargo
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          src-tauri/target/
+        key: aur-arch-native-cargo-${{ hashFiles('src-tauri/Cargo.lock') }}
+        restore-keys: aur-arch-native-cargo-
 
-   - name: Clone WebClients
-     run: git clone --depth=1 --single-branch --branch main https://github.com/ProtonMail/WebClients.git WebClients
+    - name: Clone WebClients
+      run: git clone --depth=1 --single-branch --branch main https://github.com/ProtonMail/WebClients.git WebClients
 
-   - name: Apply distro patch
-     run: |
-       AUR_TARGET="${{ github.event.inputs.aur_target || 'arch' }}"
-       AUR_PATCH="patches/aur/${AUR_TARGET}.patch"
-       if [ -f "$AUR_PATCH" ]; then
-         git apply "$AUR_PATCH"
-         echo "Applied $AUR_PATCH"
-       else
-         echo "No AUR-specific patch for ${AUR_TARGET}, skipping"
-       fi
+    - name: Apply distro patch
+      run: |
+        AUR_PATCH="patches/aur/arch-native.patch"
+        if [ -f "$AUR_PATCH" ]; then
+          git apply "$AUR_PATCH"
+          echo "Applied $AUR_PATCH"
+        else
+          echo "ERROR: No AUR patch found at $AUR_PATCH"
+          exit 1
+        fi
 
-   - name: Build WebClients
-     run: scripts/build-webclients.sh
+    - name: Build WebClients
+      run: scripts/build-webclients.sh
 
-   - name: Build Tauri binary
-     run: |
-       VERSION=$(node -p "require('./package.json').version")
-       sed -i "s/\"version\": \"[^\"]*\"/\"version\": \"$VERSION\"/" src-tauri/tauri.conf.json
-       sed -i "0,/^version = \"[^\"]*\"/s//version = \"$VERSION\"/" src-tauri/Cargo.toml
-       npm install
-       cargo build --manifest-path src-tauri/Cargo.toml --release
+    - name: Build Tauri binary
+      run: |
+        VERSION=$(node -p "require('./package.json').version")
+        sed -i "s/\"version\": \"[^\"]*\"/\"version\": \"$VERSION\"/" src-tauri/tauri.conf.json
+        sed -i "0,/^version = \"[^\"]*\"/s//version = \"$VERSION\"/" src-tauri/Cargo.toml
+        npm install
+        cargo build --manifest-path src-tauri/Cargo.toml --release
 
-   - name: Include distro wrapper
-     run: |
-       AUR_TARGET="${{ github.event.inputs.aur_target || 'arch' }}"
-       WRAPPER_FILE="patches/aur/${AUR_TARGET}.wrapper"
-       if [ -f "$WRAPPER_FILE" ]; then
-         cp "$WRAPPER_FILE" aur/proton-drive.wrapper
-         echo "Included ${AUR_TARGET} wrapper script"
-       else
-         echo "WARNING: No wrapper found for ${AUR_TARGET}"
-       fi
+    - name: Build AUR package
+      run: |
+        VERSION=$(node -p "require('./package.json').version")
+        scripts/ci/build-aur-package.sh \
+          "arch-native" \
+          "$VERSION" \
+          "src-tauri/target/release/proton-drive" \
+          "src-tauri/icons"
 
-   - name: Build AUR package
-     run: |
-       VERSION=$(node -p "require('./package.json').version")
-       scripts/ci/build-aur-package.sh \
-         "${{ github.event.inputs.aur_target || 'arch' }}" \
-         "$VERSION" \
-         "src-tauri/target/release/proton-drive" \
-         "aur/proton-drive.wrapper" \
-         "src-tauri/icons"
+    - name: Generate .SRCINFO
+      run: |
+        cd aur
+        VERSION=$(node -p "require('../package.json').version")
+        sed -i "s/^pkgver=.*/pkgver=${VERSION}/" PKGBUILD
+        sed -i "s/^pkgrel=.*/pkgrel=1/" PKGBUILD
+        makepkg --printsrcinfo > .SRCINFO 2>/dev/null || true
+        if [ ! -s .SRCINFO ]; then
+          {
+            echo "pkgbase = proton-drive"
+            echo "pkgdesc = Unofficial Linux desktop client for Proton Drive, built with Tauri"
+            echo "pkgver = ${VERSION}"
+            echo "pkgrel = 1"
+            echo "url = https://github.com/DonnieDice/protondrive-linux"
+            echo "arch = x86_64"
+            echo "license = AGPL-3.0-only"
+            echo "depends = webkit2gtk-4.1"
+            echo "depends = gtk3"
+            echo "depends = libayatana-appindicator"
+            echo "depends = openssl"
+            echo "depends = libsoup3"
+            echo "depends = librsvg"
+            echo "makedepends = cargo"
+            echo "makedepends = rust"
+            echo "makedepends = nodejs"
+            echo "makedepends = npm"
+            echo "makedepends = git"
+            echo "makedepends = pkg-config"
+            echo "makedepends = patch"
+            echo "provides = proton-drive"
+            echo "conflicts = proton-drive-bin"
+            echo "replaces = proton-drive-bin"
+            echo "options = !strip"
+            echo "pkgname = proton-drive"
+          } > .SRCINFO
+        fi
+        cat .SRCINFO
 
-   - name: Generate .SRCINFO
-     run: |
-       cd aur
-       VERSION=$(node -p "require('../package.json').version")
-       sed -i "s/^pkgver=.*/pkgver=${VERSION}/" PKGBUILD
-       sed -i "s/^pkgrel=.*/pkgrel=1/" PKGBUILD
-       makepkg --printsrcinfo > .SRCINFO 2>/dev/null || true
-       if [ ! -s .SRCINFO ]; then
-         AUR_TARGET="${{ github.event.inputs.aur_target || 'arch' }}"
-         {
-           echo "pkgbase = proton-drive-bin"
-           echo "pkgdesc = Unofficial Linux desktop client for Proton Drive, built with Tauri"
-           echo "pkgver = ${VERSION}"
-           echo "pkgrel = 1"
-           echo "url = https://github.com/DonnieDice/protondrive-linux"
-           echo "arch = x86_64"
-           echo "license = AGPL-3.0-only"
-           echo "depends = webkit2gtk-4.1"
-           echo "depends = gtk3"
-           echo "depends = libayatana-appindicator"
-           echo "provides = proton-drive"
-           echo "conflicts = proton-drive"
-           echo "options = !strip"
-           echo "source = proton-drive.wrapper"
-           echo "sha256sums = SKIP"
-           echo "pkgname = proton-drive-bin"
-         } > .SRCINFO
-       fi
-       cat .SRCINFO
+    - name: Upload AUR package
+      uses: actions/upload-artifact@v4
+      with:
+        name: aur-arch-native
+        path: /tmp/aur-output/*.pkg.tar.zst
+        if-no-files-found: error
+        retention-days: 30
 
-   - name: Upload AUR package
-     uses: actions/upload-artifact@v4
-     with:
-       name: aur-${{ github.event.inputs.aur_target || 'arch' }}
-       path: /tmp/aur-output/*.pkg.tar.zst
-       if-no-files-found: error
-       retention-days: 30
-
-   - name: Upload AUR metadata
-     uses: actions/upload-artifact@v4
-     with:
-       name: aur-${{ github.event.inputs.aur_target || 'arch' }}-srcinfo
-       path: aur/.SRCINFO
-       if-no-files-found: warn
-       include-hidden-files: true
-       retention-days: 30
+    - name: Upload AUR metadata
+      uses: actions/upload-artifact@v4
+      with:
+        name: aur-arch-native-srcinfo
+        path: aur/.SRCINFO
+        if-no-files-found: warn
+        include-hidden-files: true
+        retention-days: 30

--- a/.github/workflows/publish-aur.yml
+++ b/.github/workflows/publish-aur.yml
@@ -18,136 +18,140 @@ jobs:
     timeout-minutes: 15
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
-    - name: Get version
-      id: version
-      run: |
-        if [ -n "${{ github.event.inputs.version }}" ]; then
-          VERSION="${{ github.event.inputs.version }}"
-        else
-          VERSION="${{ github.event.release.tag_name }}"
-          VERSION="${VERSION#v}"
-        fi
-        echo "version=${VERSION}" >> $GITHUB_OUTPUT
-        echo "Publishing version: ${VERSION}"
-
-    - name: Wait for release assets
-      run: |
-        VERSION=${{ steps.version.outputs.version }}
-        ASSET_URL="https://github.com/${{ github.repository }}/releases/download/v${VERSION}/proton-drive-${VERSION}.pkg.tar.zst"
-
-        echo "Waiting for release asset: $ASSET_URL"
-
-        for i in {1..30}; do
-          if curl -sIf "$ASSET_URL" > /dev/null 2>&1; then
-            echo "Asset available!"
-            break
+      - name: Get version
+        id: version
+        run: |
+          if [ -n "${{ github.event.inputs.version }}" ]; then
+            VERSION="${{ github.event.inputs.version }}"
+          else
+            VERSION="${{ github.event.release.tag_name }}"
+            VERSION="${VERSION#v}"
           fi
-          echo "Attempt $i/30: Asset not ready, waiting 10s..."
-          sleep 10
-        done
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "Publishing version: ${VERSION}"
 
-    - name: Calculate SHA256
-      id: sha256
-      run: |
-        VERSION=${{ steps.version.outputs.version }}
-        SOURCE_URL="https://github.com/${{ github.repository }}/archive/refs/tags/v${VERSION}.tar.gz"
+      - name: Wait for source tarball
+        run: |
+          VERSION=${{ steps.version.outputs.version }}
+          SOURCE_URL="https://github.com/${{ github.repository }}/archive/refs/tags/v${VERSION}.tar.gz"
 
-        echo "Downloading source tarball to calculate checksum..."
-        curl -sL "$SOURCE_URL" -o source.tar.gz
+          echo "Waiting for source tarball: $SOURCE_URL"
 
-        SHA256=$(sha256sum source.tar.gz | cut -d' ' -f1)
-        echo "sha256=${SHA256}" >> $GITHUB_OUTPUT
-        echo "SHA256: ${SHA256}"
+          for i in {1..30}; do
+            if curl -sIf "$SOURCE_URL" > /dev/null 2>&1; then
+              echo "Source tarball available!"
+              exit 0
+            fi
+            echo "Attempt $i/30: Tarball not ready, waiting 10s..."
+            sleep 10
+          done
 
-        rm source.tar.gz
+          echo "ERROR: Source tarball not available after 5 minutes"
+          exit 1
 
-    - name: Update PKGBUILD
-      run: |
-        VERSION=${{ steps.version.outputs.version }}
-        SHA256=${{ steps.sha256.outputs.sha256 }}
+      - name: Calculate SHA256
+        id: sha256
+        run: |
+          VERSION=${{ steps.version.outputs.version }}
+          SOURCE_URL="https://github.com/${{ github.repository }}/archive/refs/tags/v${VERSION}.tar.gz"
 
-        cd aur
+          echo "Downloading source tarball to calculate checksum..."
+          curl -sL "$SOURCE_URL" -o source.tar.gz
 
-        sed -i "s/^pkgver=.*/pkgver=${VERSION}/" PKGBUILD
-        sed -i "s/^pkgrel=.*/pkgrel=1/" PKGBUILD
-        sed -i "s/^sha256sums=.*/sha256sums=('${SHA256}')/" PKGBUILD
+          SHA256=$(sha256sum source.tar.gz | cut -d' ' -f1)
+          echo "sha256=${SHA256}" >> $GITHUB_OUTPUT
+          echo "SHA256: ${SHA256}"
 
-        echo "Updated PKGBUILD:"
-        cat PKGBUILD
+          rm source.tar.gz
 
-    - name: Generate .SRCINFO
-      run: |
-        cd aur
+      - name: Update PKGBUILD
+        run: |
+          VERSION=${{ steps.version.outputs.version }}
+          SHA256=${{ steps.sha256.outputs.sha256 }}
 
-        cat > .SRCINFO << EOF
-        pkgbase = proton-drive
-        pkgdesc = Unofficial Linux desktop client for Proton Drive, built with Tauri
-        pkgver = ${{ steps.version.outputs.version }}
-        pkgrel = 1
-        url = https://github.com/DonnieDice/protondrive-linux
-        arch = x86_64
-        license = AGPL-3.0-only
-        depends = webkit2gtk-4.1
-        depends = gtk3
-        depends = libayatana-appindicator
-        depends = openssl
-        depends = libsoup3
-        depends = librsvg
-        makedepends = cargo
-        makedepends = rust
-        makedepends = nodejs
-        makedepends = npm
-        makedepends = git
-        makedepends = pkg-config
-        makedepends = patch
-        provides = proton-drive
-        conflicts = proton-drive-bin
-        replaces = proton-drive-bin
-        options = !strip
-        source = proton-drive-${{ steps.version.outputs.version }}.tar.gz::https://github.com/DonnieDice/protondrive-linux/archive/refs/tags/v${{ steps.version.outputs.version }}.tar.gz
-        sha256sums = ${{ steps.sha256.outputs.sha256 }}
+          cd aur
 
-        pkgname = proton-drive
-        EOF
+          sed -i "s/^pkgver=.*/pkgver=${VERSION}/" PKGBUILD
+          sed -i "s/^pkgrel=.*/pkgrel=1/" PKGBUILD
+          sed -i "s/^sha256sums=.*/sha256sums=('${SHA256}')/" PKGBUILD
 
-        echo "Generated .SRCINFO:"
-        cat .SRCINFO
+          echo "Updated PKGBUILD:"
+          cat PKGBUILD
 
-    - name: Setup SSH
-      run: |
-        mkdir -p ~/.ssh
-        echo "${{ secrets.AUR_SSH_KEY }}" > ~/.ssh/aur
-        chmod 600 ~/.ssh/aur
+      - name: Generate .SRCINFO
+        run: |
+          cd aur
 
-        cat >> ~/.ssh/config << EOF
-        Host aur.archlinux.org
-        IdentityFile ~/.ssh/aur
-        User aur
-        StrictHostKeyChecking no
-        EOF
+          cat > .SRCINFO << EOF
+          pkgbase = proton-drive
+          	pkgdesc = Unofficial Linux desktop client for Proton Drive, built with Tauri
+          	pkgver = ${{ steps.version.outputs.version }}
+          	pkgrel = 1
+          	url = https://github.com/DonnieDice/protondrive-linux
+          	arch = x86_64
+          	license = AGPL-3.0-only
+          	depends = webkit2gtk-4.1
+          	depends = gtk3
+          	depends = libayatana-appindicator
+          	depends = openssl
+          	depends = libsoup3
+          	depends = librsvg
+          	makedepends = cargo
+          	makedepends = rust
+          	makedepends = nodejs
+          	makedepends = npm
+          	makedepends = git
+          	makedepends = pkg-config
+          	makedepends = patch
+          	makedepends = python
+          	provides = proton-drive
+          	conflicts = proton-drive-bin
+          	replaces = proton-drive-bin
+          	options = !strip
+          	source = proton-drive-${{ steps.version.outputs.version }}.tar.gz::https://github.com/DonnieDice/protondrive-linux/archive/refs/tags/v${{ steps.version.outputs.version }}.tar.gz
+          	sha256sums = ${{ steps.sha256.outputs.sha256 }}
 
-    - name: Clone AUR package
-      run: |
-        git clone ssh://aur@aur.archlinux.org/proton-drive.git aur-repo || \
-          { mkdir -p aur-repo && cd aur-repo && git init && git remote add origin ssh://aur@aur.archlinux.org/proton-drive.git; }
+          	pkgname = proton-drive
+          EOF
 
-        cd aur-repo
-        git config user.name "DonnieDice"
-        git config user.email "donniedice@proton.me"
+          echo "Generated .SRCINFO:"
+          cat .SRCINFO
 
-    - name: Update AUR package
-      run: |
-        cp aur/PKGBUILD aur-repo/
-        cp aur/.SRCINFO aur-repo/
+      - name: Setup SSH
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.AUR_SSH_KEY }}" > ~/.ssh/aur
+          chmod 600 ~/.ssh/aur
 
-        cd aur-repo
-        git add PKGBUILD .SRCINFO
-        git commit -m "Update to v${{ steps.version.outputs.version }}" || echo "No changes to commit"
-        git push origin master || git push origin main || echo "Push may have failed - check AUR manually"
+          cat >> ~/.ssh/config << EOF
+          Host aur.archlinux.org
+            IdentityFile ~/.ssh/aur
+            User aur
+            StrictHostKeyChecking no
+          EOF
 
-    - name: Cleanup
-      if: always()
-      run: rm -rf ~/.ssh/aur
+      - name: Clone AUR package
+        run: |
+          git clone ssh://aur@aur.archlinux.org/proton-drive.git aur-repo || \
+            { mkdir -p aur-repo && cd aur-repo && git init && git remote add origin ssh://aur@aur.archlinux.org/proton-drive.git; }
+
+          cd aur-repo
+          git config user.name "DonnieDice"
+          git config user.email "donniedice@proton.me"
+
+      - name: Update AUR package
+        run: |
+          cp aur/PKGBUILD aur-repo/
+          cp aur/.SRCINFO aur-repo/
+
+          cd aur-repo
+          git add PKGBUILD .SRCINFO
+          git commit -m "Update to v${{ steps.version.outputs.version }}" || echo "No changes to commit"
+          git push origin master || git push origin main || echo "Push may have failed - check AUR manually"
+
+      - name: Cleanup
+        if: always()
+        run: rm -rf ~/.ssh/aur

--- a/.github/workflows/publish-aur.yml
+++ b/.github/workflows/publish-aur.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version to publish (e.g., 1.2.2)'
+        description: 'Version to publish (e.g., 1.4.0)'
         required: true
 
 permissions:
@@ -18,136 +18,136 @@ jobs:
     timeout-minutes: 15
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
+    - name: Checkout repository
+      uses: actions/checkout@v4
 
-      - name: Get version
-        id: version
-        run: |
-          if [ -n "${{ github.event.inputs.version }}" ]; then
-            VERSION="${{ github.event.inputs.version }}"
-          else
-            VERSION="${{ github.event.release.tag_name }}"
-            VERSION="${VERSION#v}"  # Remove 'v' prefix
+    - name: Get version
+      id: version
+      run: |
+        if [ -n "${{ github.event.inputs.version }}" ]; then
+          VERSION="${{ github.event.inputs.version }}"
+        else
+          VERSION="${{ github.event.release.tag_name }}"
+          VERSION="${VERSION#v}"
+        fi
+        echo "version=${VERSION}" >> $GITHUB_OUTPUT
+        echo "Publishing version: ${VERSION}"
+
+    - name: Wait for release assets
+      run: |
+        VERSION=${{ steps.version.outputs.version }}
+        ASSET_URL="https://github.com/${{ github.repository }}/releases/download/v${VERSION}/proton-drive-${VERSION}.pkg.tar.zst"
+
+        echo "Waiting for release asset: $ASSET_URL"
+
+        for i in {1..30}; do
+          if curl -sIf "$ASSET_URL" > /dev/null 2>&1; then
+            echo "Asset available!"
+            break
           fi
-          echo "version=${VERSION}" >> $GITHUB_OUTPUT
-          echo "Publishing version: ${VERSION}"
+          echo "Attempt $i/30: Asset not ready, waiting 10s..."
+          sleep 10
+        done
 
-      - name: Wait for release assets
-        run: |
-          VERSION=${{ steps.version.outputs.version }}
-          ASSET_URL="https://github.com/${{ github.repository }}/releases/download/v${VERSION}/proton-drive_${VERSION}_amd64.AppImage"
+    - name: Calculate SHA256
+      id: sha256
+      run: |
+        VERSION=${{ steps.version.outputs.version }}
+        SOURCE_URL="https://github.com/${{ github.repository }}/archive/refs/tags/v${VERSION}.tar.gz"
 
-          echo "Waiting for release asset: $ASSET_URL"
+        echo "Downloading source tarball to calculate checksum..."
+        curl -sL "$SOURCE_URL" -o source.tar.gz
 
-          for i in {1..30}; do
-            if curl -sIf "$ASSET_URL" > /dev/null 2>&1; then
-              echo "Asset available!"
-              break
-            fi
-            echo "Attempt $i/30: Asset not ready, waiting 10s..."
-            sleep 10
-          done
+        SHA256=$(sha256sum source.tar.gz | cut -d' ' -f1)
+        echo "sha256=${SHA256}" >> $GITHUB_OUTPUT
+        echo "SHA256: ${SHA256}"
 
-      - name: Calculate SHA256
-        id: sha256
-        run: |
-          VERSION=${{ steps.version.outputs.version }}
-          ASSET_URL="https://github.com/${{ github.repository }}/releases/download/v${VERSION}/proton-drive_${VERSION}_amd64.AppImage"
+        rm source.tar.gz
 
-          echo "Downloading AppImage to calculate checksum..."
-          curl -sL "$ASSET_URL" -o appimage.AppImage
+    - name: Update PKGBUILD
+      run: |
+        VERSION=${{ steps.version.outputs.version }}
+        SHA256=${{ steps.sha256.outputs.sha256 }}
 
-          SHA256=$(sha256sum appimage.AppImage | cut -d' ' -f1)
-          echo "sha256=${SHA256}" >> $GITHUB_OUTPUT
-          echo "SHA256: ${SHA256}"
+        cd aur
 
-          rm appimage.AppImage
+        sed -i "s/^pkgver=.*/pkgver=${VERSION}/" PKGBUILD
+        sed -i "s/^pkgrel=.*/pkgrel=1/" PKGBUILD
+        sed -i "s/^sha256sums=.*/sha256sums=('${SHA256}')/" PKGBUILD
 
-      - name: Update PKGBUILD
-        run: |
-          VERSION=${{ steps.version.outputs.version }}
-          SHA256=${{ steps.sha256.outputs.sha256 }}
+        echo "Updated PKGBUILD:"
+        cat PKGBUILD
 
-          cd aur
+    - name: Generate .SRCINFO
+      run: |
+        cd aur
 
-          # Update version
-          sed -i "s/^pkgver=.*/pkgver=${VERSION}/" PKGBUILD
+        cat > .SRCINFO << EOF
+        pkgbase = proton-drive
+        pkgdesc = Unofficial Linux desktop client for Proton Drive, built with Tauri
+        pkgver = ${{ steps.version.outputs.version }}
+        pkgrel = 1
+        url = https://github.com/DonnieDice/protondrive-linux
+        arch = x86_64
+        license = AGPL-3.0-only
+        depends = webkit2gtk-4.1
+        depends = gtk3
+        depends = libayatana-appindicator
+        depends = openssl
+        depends = libsoup3
+        depends = librsvg
+        makedepends = cargo
+        makedepends = rust
+        makedepends = nodejs
+        makedepends = npm
+        makedepends = git
+        makedepends = pkg-config
+        makedepends = patch
+        provides = proton-drive
+        conflicts = proton-drive-bin
+        replaces = proton-drive-bin
+        options = !strip
+        source = proton-drive-${{ steps.version.outputs.version }}.tar.gz::https://github.com/DonnieDice/protondrive-linux/archive/refs/tags/v${{ steps.version.outputs.version }}.tar.gz
+        sha256sums = ${{ steps.sha256.outputs.sha256 }}
 
-          # Reset pkgrel to 1 for new version
-          sed -i "s/^pkgrel=.*/pkgrel=1/" PKGBUILD
+        pkgname = proton-drive
+        EOF
 
-          # Update SHA256
-          sed -i "s/^sha256sums=.*/sha256sums=('${SHA256}')/" PKGBUILD
+        echo "Generated .SRCINFO:"
+        cat .SRCINFO
 
-          echo "Updated PKGBUILD:"
-          cat PKGBUILD
+    - name: Setup SSH
+      run: |
+        mkdir -p ~/.ssh
+        echo "${{ secrets.AUR_SSH_KEY }}" > ~/.ssh/aur
+        chmod 600 ~/.ssh/aur
 
-      - name: Generate .SRCINFO
-        run: |
-          cd aur
+        cat >> ~/.ssh/config << EOF
+        Host aur.archlinux.org
+        IdentityFile ~/.ssh/aur
+        User aur
+        StrictHostKeyChecking no
+        EOF
 
-          # Install makepkg dependencies
-          sudo apt-get update
-          sudo apt-get install -y pacman-package-manager libarchive-tools
+    - name: Clone AUR package
+      run: |
+        git clone ssh://aur@aur.archlinux.org/proton-drive.git aur-repo || \
+          { mkdir -p aur-repo && cd aur-repo && git init && git remote add origin ssh://aur@aur.archlinux.org/proton-drive.git; }
 
-          # Generate .SRCINFO manually since we can't run makepkg on Ubuntu
-          cat > .SRCINFO << EOF
-          pkgbase = proton-drive-bin
-          	pkgdesc = Unofficial Linux desktop client for Proton Drive, built with Tauri
-          	pkgver = ${{ steps.version.outputs.version }}
-          	pkgrel = 1
-          	url = https://github.com/DonnieDice/protondrive-linux
-          	arch = x86_64
-          	license = AGPL-3.0-only
-          	depends = webkit2gtk-4.1
-          	depends = gtk3
-          	depends = libayatana-appindicator
-          	provides = proton-drive
-          	conflicts = proton-drive
-          	options = !strip
-          	source = proton-drive-bin-${{ steps.version.outputs.version }}.AppImage::https://github.com/DonnieDice/protondrive-linux/releases/download/v${{ steps.version.outputs.version }}/proton-drive_${{ steps.version.outputs.version }}_amd64.AppImage
-          	sha256sums = ${{ steps.sha256.outputs.sha256 }}
+        cd aur-repo
+        git config user.name "DonnieDice"
+        git config user.email "donniedice@proton.me"
 
-          pkgname = proton-drive-bin
-          EOF
+    - name: Update AUR package
+      run: |
+        cp aur/PKGBUILD aur-repo/
+        cp aur/.SRCINFO aur-repo/
 
-          echo "Generated .SRCINFO:"
-          cat .SRCINFO
+        cd aur-repo
+        git add PKGBUILD .SRCINFO
+        git commit -m "Update to v${{ steps.version.outputs.version }}" || echo "No changes to commit"
+        git push origin master || git push origin main || echo "Push may have failed - check AUR manually"
 
-      - name: Setup SSH
-        run: |
-          mkdir -p ~/.ssh
-          echo "${{ secrets.AUR_SSH_KEY }}" > ~/.ssh/aur
-          chmod 600 ~/.ssh/aur
-
-          cat >> ~/.ssh/config << EOF
-          Host aur.archlinux.org
-            IdentityFile ~/.ssh/aur
-            User aur
-            StrictHostKeyChecking no
-          EOF
-
-      - name: Clone AUR package
-        run: |
-          git clone ssh://aur@aur.archlinux.org/proton-drive-bin.git aur-repo || \
-          git clone ssh://aur@aur.archlinux.org/proton-drive-bin.git aur-repo 2>&1 | grep -q "does not appear to be a git repository" && \
-          mkdir -p aur-repo && cd aur-repo && git init
-
-          cd aur-repo
-          git config user.name "DonnieDice"
-          git config user.email "donniedice@proton.me"
-
-      - name: Update AUR package
-        run: |
-          cp aur/PKGBUILD aur-repo/
-          cp aur/.SRCINFO aur-repo/
-
-          cd aur-repo
-          git add PKGBUILD .SRCINFO
-          git commit -m "Update to v${{ steps.version.outputs.version }}" || echo "No changes to commit"
-          git push origin master || git push origin main || echo "Push may have failed - check AUR manually"
-
-      - name: Cleanup
-        if: always()
-        run: rm -rf ~/.ssh/aur
+    - name: Cleanup
+      if: always()
+      run: rm -rf ~/.ssh/aur

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,7 @@ jobs:
           'Build Flatpak GNOME 49',
           'Build Snap',
           'Build Snap Core26',
-          'Build AUR',
+          'Build AUR Arch Native',
           'Build DEB Debian 12',
           'Build DEB Debian 13',
           'Build DEB Ubuntu 24.04',
@@ -151,15 +151,15 @@ jobs:
           workflow_conclusion: success
           if_no_artifact_found: fail
 
-      - name: Download AUR artifact
-        uses: dawidd6/action-download-artifact@v6
-        with:
-          workflow: build-aur.yml
-          name: aur-arch
-          path: artifacts/aur
-          commit: ${{ github.sha }}
-          workflow_conclusion: success
-          if_no_artifact_found: fail
+- name: Download AUR artifact
+  uses: dawidd6/action-download-artifact@v6
+  with:
+    workflow: build-aur.yml
+    name: aur-arch-native
+    path: artifacts/aur
+    commit: ${{ github.sha }}
+    workflow_conclusion: success
+    if_no_artifact_found: fail
 
       - name: Download DEB Debian 12 artifact
         uses: dawidd6/action-download-artifact@v6

--- a/aur/PKGBUILD
+++ b/aur/PKGBUILD
@@ -1,47 +1,52 @@
 # Maintainer: DonnieDice <donniedice@proton.me>
-pkgname=proton-drive-bin
+pkgname=proton-drive
 pkgver=1.3.2
 pkgrel=1
 pkgdesc="Unofficial Linux desktop client for Proton Drive, built with Tauri"
 arch=('x86_64')
 url="https://github.com/DonnieDice/protondrive-linux"
 license=('AGPL-3.0-only')
-depends=('webkit2gtk-4.1' 'gtk3' 'libayatana-appindicator')
+depends=('webkit2gtk-4.1' 'gtk3' 'libayatana-appindicator' 'openssl' 'libsoup3' 'librsvg')
+makedepends=('cargo' 'rust' 'nodejs' 'npm' 'git' 'pkg-config' 'patch')
+optdepends=('libappindicator-gtk3: system tray support (GNOME)')
 provides=('proton-drive')
-conflicts=('proton-drive')
+conflicts=('proton-drive-bin')
+replaces=('proton-drive-bin')
 options=('!strip')
-source=("${pkgname}-${pkgver}.AppImage::https://github.com/DonnieDice/protondrive-linux/releases/download/v${pkgver}/proton-drive_${pkgver}_amd64.AppImage"
-        "proton-drive.wrapper")
-sha256sums=('SKIP'
-            'SKIP')
+source=("${pkgname}-${pkgver}.tar.gz::https://github.com/DonnieDice/protondrive-linux/archive/refs/tags/v${pkgver}.tar.gz")
+sha256sums=('SKIP')
 
-prepare() {
-    chmod +x "${pkgname}-${pkgver}.AppImage"
-    "./${pkgname}-${pkgver}.AppImage" --appimage-extract
+build() {
+  cd "${srcdir}/${pkgname}-${pkgver}"
+
+  git clone --depth=1 --single-branch --branch main https://github.com/ProtonMail/WebClients.git WebClients
+
+  npm install
+
+  scripts/build-webclients.sh
+
+  git apply patches/aur/arch-native.patch
+
+  cd src-tauri
+  cargo build --release
 }
 
 package() {
-    install -dm755 "${pkgdir}/usr/lib/proton-drive"
-    install -Dm755 "${srcdir}/squashfs-root/usr/bin/proton-drive" "${pkgdir}/usr/lib/proton-drive/proton-drive.bin"
+  cd "${srcdir}/${pkgname}-${pkgver}"
 
-    install -Dm755 "${srcdir}/proton-drive.wrapper" "${pkgdir}/usr/bin/proton-drive"
+  install -Dm755 "src-tauri/target/release/proton-drive" "${pkgdir}/usr/bin/proton-drive"
+  install -Dm644 "src-tauri/icons/com.proton.drive.desktop" \
+    "${pkgdir}/usr/share/applications/com.proton.drive.desktop" || true
 
-    install -Dm644 "${srcdir}/squashfs-root/usr/share/applications/com.proton.drive.desktop" \
-        "${pkgdir}/usr/share/applications/com.proton.drive.desktop"
-
-    for size in 32x32 128x128 256x256; do
-        if [ -f "${srcdir}/squashfs-root/usr/share/icons/hicolor/${size}/apps/com.proton.drive.png" ]; then
-            install -Dm644 "${srcdir}/squashfs-root/usr/share/icons/hicolor/${size}/apps/com.proton.drive.png" \
-                "${pkgdir}/usr/share/icons/hicolor/${size}/apps/com.proton.drive.png"
-        fi
-    done
-
-    if [ -f "${srcdir}/squashfs-root/usr/share/icons/hicolor/scalable/apps/com.proton.drive.svg" ]; then
-        install -Dm644 "${srcdir}/squashfs-root/usr/share/icons/hicolor/scalable/apps/com.proton.drive.svg" \
-            "${pkgdir}/usr/share/icons/hicolor/scalable/apps/com.proton.drive.svg"
+  for size in 32x32 128x128 256x256; do
+    if [ -f "src-tauri/icons/${size}/apps/com.proton.drive.png" ]; then
+      install -Dm644 "src-tauri/icons/${size}/apps/com.proton.drive.png" \
+        "${pkgdir}/usr/share/icons/hicolor/${size}/apps/com.proton.drive.png"
     fi
+  done
 
-    if [ -d "${srcdir}/squashfs-root/usr/lib" ]; then
-        cp -r "${srcdir}/squashfs-root/usr/lib" "${pkgdir}/usr/"
-    fi
+  if [ -f "src-tauri/icons/scalable/apps/com.proton.drive.svg" ]; then
+    install -Dm644 "src-tauri/icons/scalable/apps/com.proton.drive.svg" \
+      "${pkgdir}/usr/share/icons/hicolor/scalable/apps/com.proton.drive.svg"
+  fi
 }

--- a/aur/PKGBUILD
+++ b/aur/PKGBUILD
@@ -1,23 +1,24 @@
 # Maintainer: DonnieDice <donniedice@proton.me>
 pkgname=proton-drive
-pkgver=1.3.2
+pkgver=1.4.0
 pkgrel=1
 pkgdesc="Unofficial Linux desktop client for Proton Drive, built with Tauri"
 arch=('x86_64')
 url="https://github.com/DonnieDice/protondrive-linux"
 license=('AGPL-3.0-only')
 depends=('webkit2gtk-4.1' 'gtk3' 'libayatana-appindicator' 'openssl' 'libsoup3' 'librsvg')
-makedepends=('cargo' 'rust' 'nodejs' 'npm' 'git' 'pkg-config' 'patch')
+makedepends=('cargo' 'rust' 'nodejs' 'npm' 'git' 'pkg-config' 'patch' 'python')
 optdepends=('libappindicator-gtk3: system tray support (GNOME)')
 provides=('proton-drive')
 conflicts=('proton-drive-bin')
 replaces=('proton-drive-bin')
 options=('!strip')
-source=("${pkgname}-${pkgver}.tar.gz::https://github.com/DonnieDice/protondrive-linux/archive/refs/tags/v${pkgver}.tar.gz")
+_source_dir="protondrive-linux-${pkgver}"
+source=("${_source_dir}.tar.gz::https://github.com/DonnieDice/protondrive-linux/archive/refs/tags/v${pkgver}.tar.gz")
 sha256sums=('SKIP')
 
 build() {
-  cd "${srcdir}/${pkgname}-${pkgver}"
+	cd "${srcdir}/${_source_dir}"
 
   git clone --depth=1 --single-branch --branch main https://github.com/ProtonMail/WebClients.git WebClients
 
@@ -32,21 +33,34 @@ build() {
 }
 
 package() {
-  cd "${srcdir}/${pkgname}-${pkgver}"
+	cd "${srcdir}/${_source_dir}"
 
-  install -Dm755 "src-tauri/target/release/proton-drive" "${pkgdir}/usr/bin/proton-drive"
-  install -Dm644 "src-tauri/icons/com.proton.drive.desktop" \
-    "${pkgdir}/usr/share/applications/com.proton.drive.desktop" || true
+	install -Dm755 "src-tauri/target/release/proton-drive" "${pkgdir}/usr/bin/proton-drive"
 
-  for size in 32x32 128x128 256x256; do
-    if [ -f "src-tauri/icons/${size}/apps/com.proton.drive.png" ]; then
-      install -Dm644 "src-tauri/icons/${size}/apps/com.proton.drive.png" \
-        "${pkgdir}/usr/share/icons/hicolor/${size}/apps/com.proton.drive.png"
-    fi
-  done
+	install -Dm644 /dev/stdin "${pkgdir}/usr/share/applications/com.proton.drive.desktop" <<DESKTOP
+[Desktop Entry]
+Version=1.0
+Type=Application
+Name=Proton Drive
+Comment=Secure cloud storage
+Exec=proton-drive %U
+Icon=com.proton.drive
+Categories=Utility;Network;FileTransfer;
+Keywords=proton;drive;cloud;storage;sync;
+Terminal=false
+StartupWMClass=proton-drive
+StartupNotify=true
+DESKTOP
 
-  if [ -f "src-tauri/icons/scalable/apps/com.proton.drive.svg" ]; then
-    install -Dm644 "src-tauri/icons/scalable/apps/com.proton.drive.svg" \
-      "${pkgdir}/usr/share/icons/hicolor/scalable/apps/com.proton.drive.svg"
-  fi
+	install -Dm644 "src-tauri/icons/32x32.png" \
+		"${pkgdir}/usr/share/icons/hicolor/32x32/apps/com.proton.drive.png"
+	install -Dm644 "src-tauri/icons/128x128.png" \
+		"${pkgdir}/usr/share/icons/hicolor/128x128/apps/com.proton.drive.png"
+	install -Dm644 "src-tauri/icons/128x128@2x.png" \
+		"${pkgdir}/usr/share/icons/hicolor/256x256/apps/com.proton.drive.png"
+
+	if [ -f "src-tauri/icons/proton-drive.svg" ]; then
+		install -Dm644 "src-tauri/icons/proton-drive.svg" \
+			"${pkgdir}/usr/share/icons/hicolor/scalable/apps/com.proton.drive.svg"
+	fi
 }

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -82,7 +82,7 @@ described above. Both must pass for a target to be `release-gated`.
 | Flatpak GNOME 50 | runtime | runtime | `build-flatpak.yml` / `flatpak-package` | `flatpak/org.gnome.Platform.50.patch` | remote artifact pass | GNOME Platform 50 runtime | keep in release gate |
 | Snap core24 | runtime | runtime | `build-snap.yml` / `snap-package` | `snap/core24.patch` | remote artifact pass | Snap core24 base | keep in release gate |
 | Snap core26 | runtime | runtime | `build-snap.core26.yml` / `snap-package-core26` | `snap/core26.patch` | remote artifact pass | Snap core26 base | keep in release gate |
-| AUR Arch package (AppImage wrapper) | pass (glibc 2.39) | pass | `build-aur.yml` / `aur-arch` | `aur/arch.patch` + `aur/arch.wrapper` | remote artifact pass | Arch, Manjaro, EndeavourOS, Garuda | keep in release gate; plan migration to native build |
+| AUR Arch package (native build) | pass (glibc 2.39) | pass | `build-aur.yml` / `aur-arch-native` | `aur/arch-native.patch` | remote artifact pass | Arch, Manjaro, EndeavourOS, Garuda | keep in release gate |
 
 ### Roadmap patch-ready targets
 
@@ -97,7 +97,6 @@ described above. Both must pass for a target to be `release-gated`.
 
 | Package target | glibc gate | WebKitGTK gate | Covered systems / rule | Next action |
 |----------------|-----------|----------------|------------------------|-------------|
-| AUR native Arch build | pass | pass | Arch, Manjaro, EndeavourOS, Garuda; replaces current AppImage-wrapper AUR with a natively compiled package | design native PKGBUILD, add CI workflow, create patch, validate smoke test |
 | Nix flake | n/a (Nix manages libc) | pass (nixpkgs provides) | NixOS and any host with Nix | design flake.nix, add CI workflow, create patch, validate smoke test |
 | Gentoo ebuild | pass | pass | Gentoo | design ebuild, add CI workflow, create patch, validate smoke test |
 | Slackware package | pass | verify | Slackware current; WebKitGTK 4.1 availability must be confirmed for target | verify WebKitGTK 4.1 in Slackware current repos, then design package, workflow, and patch |
@@ -134,9 +133,7 @@ described above. Both must pass for a target to be `release-gated`.
 - Linux Mint, Pop!_OS, Zorin, and similar Ubuntu derivatives use the Ubuntu DEB
   that matches their Ubuntu base.
 - Arch derivatives use the AUR target or AppImage.
-- The current AUR package wraps the AppImage. A future native AUR build will
-  compile against Arch system packages and replace the wrapper. Both targets
-  will coexist until the native build is smoke-tested.
+- The AUR package is a native build that compiles against Arch system packages. It replaced the former AppImage-wrapper package (`proton-drive-bin`) in v1.4.0.
 - RHEL 10, CentOS Stream 10, AlmaLinux 10, and Rocky Linux 10 share the EL10 RPM
   line.
 - openSUSE Tumbleweed users use the Tumbleweed RPM. Leap 16 users should use AppImage until a Leap 16 RPM workflow and smoke test are added.
@@ -183,8 +180,7 @@ Patch tree:
 patches/
 |-- common/fix-tauri-worker-protocol.patch
 |-- appimage/linux-baseline.patch
-|-- aur/arch.patch
-|-- aur/arch-native.patch (roadmap: native AUR build)
+|-- aur/arch-native.patch
 |-- deb/debian.12.patch
 |-- deb/debian.13.patch
 |-- deb/ubuntu.24.04.patch
@@ -219,8 +215,7 @@ Runtime settings by baseline:
 | Alpine roadmap | musl package target plus current-WebKitGTK conservative path |
 | Flatpak GNOME 49/50 | runtime-specific WebKitGTK settings for GNOME Platform targets |
 | Snap core24/core26 | wrapper/manifest WebKit paths plus package patch behavior |
-| AUR (AppImage wrapper) | Arch-family wrapper and patch for current WebKitGTK |
-| AUR (native) roadmap | Arch-family native build against system WebKitGTK; runtime settings TBD after smoke test |
+| AUR (native) | sandbox disable, `JSC_useWasmIPInt=false`; hardware rendering kept |
 | Nix roadmap | nixpkgs-managed WebKitGTK; runtime settings TBD after smoke test |
 | Gentoo roadmap | system WebKitGTK; runtime settings TBD after smoke test |
 | Slackware roadmap | Slackware current WebKitGTK; runtime settings TBD after smoke test |

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -35,9 +35,9 @@ Use this checklist before every release deployment.
   - [ ] RPM workflows are passing.
   - [ ] Flatpak workflows are passing.
   - [ ] Snap workflows are passing.
-  - [ ] AUR workflow is passing.
-  - [ ] APK Alpine 3.20 workflow is passing.
-  - [ ] Release workflow is passing.
+- [ ] AUR workflow is passing.
+- [ ] APK Alpine 3.20 workflow is passing.
+- [ ] Release workflow is passing.
 
 - [ ] Merge `dev` to `main` directly.
   - [ ] Confirm `dev` contains only commits intended for the release.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "protondrive-linux",
-  "version": "1.3.2",
+  "version": "1.4.0",
   "description": "Proton Drive desktop client for Linux",
   "repository": {
     "type": "git",

--- a/packaging/compatibility-map.yml
+++ b/packaging/compatibility-map.yml
@@ -154,16 +154,12 @@ appimage:
 
 aur:
   arch:
-    status: release-gated
+    status: replaced
     gates:
       glibc: pass
       webkitgtk: pass
     packaging_mode: appimage-wrapper
-    runtime_smoke:
-      status: pass
-      evidence: remote artifact pass
-    workflow: .github/workflows/build-aur.yml
-    publish_workflow: .github/workflows/publish-aur.yml
+    workflow: null
     build_container: archlinux:base-devel
     release_label: aur-arch
     artifact_name: aur-arch
@@ -174,7 +170,30 @@ aur:
     - manjaro
     - endeavour
     - garuda
-    migration_note: "Current AUR package wraps the AppImage. A future native AUR build (arch-native) will compile against Arch system packages and replace this wrapper."
+    replaced_by: arch_native
+    replacement_note: "Replaced by native AUR build (proton-drive) in v1.4.0. The appimage-wrapper package proton-drive-bin is superseded."
+  arch_native:
+    status: release-gated
+    gates:
+      glibc: pass
+      webkitgtk: pass
+    packaging_mode: native
+    runtime_smoke:
+      status: pass
+      evidence: remote artifact pass
+    workflow: .github/workflows/build-aur.yml
+    publish_workflow: .github/workflows/publish-aur.yml
+    build_container: archlinux:base-devel
+    release_label: aur-arch-native
+    artifact_name: aur-arch-native
+    metadata_artifact_name: aur-arch-native-srcinfo
+    patch: arch-native
+    replaces: arch
+    supports:
+    - arch
+    - manjaro
+    - endeavour
+    - garuda
 
 flatpak:
   org.gnome.Platform.49:
@@ -319,30 +338,6 @@ roadmap_patch_ready:
       - validate musl runtime install and login smoke test
 
 roadmap:
-  aur:
-    arch_native:
-      status: roadmap
-      gates:
-        glibc: pass
-        webkitgtk: pass
-      packaging_mode: native
-      workflow: null
-      build_container: archlinux:base-devel
-      release_label: aur-arch-native
-      artifact_name: aur-arch-native
-      patch: arch-native
-      supports:
-      - arch
-      - manjaro
-      - endeavour
-      - garuda
-      replaces: arch
-      before_release_gate:
-      - design native PKGBUILD that compiles against system WebKitGTK
-      - add CI workflow for native AUR build
-      - create arch-native patch
-      - validate runtime install and login smoke test on Arch
-      - plan migration from appimage-wrapper to native AUR
   nix:
     nixos:
       status: roadmap

--- a/patches/README.md
+++ b/patches/README.md
@@ -39,8 +39,7 @@ patches/
 |   |-- core24.patch
 |   `-- core26.patch
 `-- aur/
-    |-- arch.patch
-    `-- arch.wrapper
+  `-- arch-native.patch
 ```
 
 ## Release-Gated Patches
@@ -48,7 +47,7 @@ patches/
 These are currently built and published by the release workflow:
 
 - `appimage/linux-baseline.patch`
-- `aur/arch.patch`
+- `aur/arch-native.patch`
 - `deb/debian.12.patch`
 - `deb/debian.13.patch`
 - `deb/ubuntu.24.04.patch`

--- a/patches/aur/arch-native.patch
+++ b/patches/aur/arch-native.patch
@@ -1,23 +1,20 @@
 diff --git a/src-tauri/src/main.rs b/src-tauri/src/main.rs
-index 51d68ebd..f62bca2b 100644
+index 51d68ebd..01bba427 100644
 --- a/src-tauri/src/main.rs
 +++ b/src-tauri/src/main.rs
-@@ -194,9 +194,15 @@ async fn proxy_request(
+@@ -194,9 +194,12 @@ async fn proxy_request(
  }
  
  fn main() {
 -    // NOTE: WebKitGTK env vars (GDK_GL, WEBKIT_DISABLE_*, etc.) are NOT set here.
 -    // They are distro-specific and belong in patches/<package>/<distro>.patch
 -    // and the package's AppRun/wrapper script. The base binary ships clean.
-+    // WebKitGTK environment for Arch (webkit2gtk 2.52+).
-+    // New sandbox API; disable IPInt WASM to avoid SIGTRAP after 2FA.
++    // WebKitGTK environment for Arch native build (webkit2gtk 2.52+).
++    // Disable sandbox and IPInt WASM; keep hardware rendering.
 +    std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
 +    std::env::set_var("WEBKIT_DISABLE_COMPOSITING_MODE", "1");
 +    std::env::set_var("WEBKIT_DISABLE_SANDBOX_THIS_IS_DANGEROUS", "1");
 +    std::env::set_var("JSC_useWasmIPInt", "false");
-+    std::env::set_var("GDK_GL", "disable");
-+    std::env::set_var("LIBGL_ALWAYS_SOFTWARE", "1");
-+    std::env::set_var("GSK_RENDERER", "cairo");
  
      // Create shared client with cookie jar
      let state = Arc::new(AppState {

--- a/patches/aur/arch.wrapper
+++ b/patches/aur/arch.wrapper
@@ -1,9 +1,0 @@
-#!/bin/bash
-export WEBKIT_DISABLE_DMABUF_RENDERER=1
-export WEBKIT_DISABLE_COMPOSITING_MODE=1
-export WEBKIT_DISABLE_SANDBOX_THIS_IS_DANGEROUS=1
-export JSC_useWasmIPInt=false
-export GDK_GL=disable
-export LIBGL_ALWAYS_SOFTWARE=1
-export GSK_RENDERER=cairo
-exec /usr/lib/proton-drive/proton-drive.bin "$@"

--- a/scripts/ci/build-aur-package.sh
+++ b/scripts/ci/build-aur-package.sh
@@ -35,20 +35,38 @@ StartupNotify=true
 DESKTOP
 
 if [ -d "$ICONS_DIR" ]; then
-  for size in 32x32 128x128 256x256; do
-    case "$size" in
-      32x32) ICON_FILE="${ICONS_DIR}/32x32.png" ;;
-      128x128) ICON_FILE="${ICONS_DIR}/128x128.png" ;;
-      256x256) ICON_FILE="${ICONS_DIR}/128x128@2x.png" ;;
-    esac
-    if [ -f "$ICON_FILE" ]; then
-      cp "$ICON_FILE" "${SRC_DIR}/icon-${size}.png"
-    fi
-  done
-  if [ -f "${ICONS_DIR}/proton-drive.svg" ]; then
-    cp "${ICONS_DIR}/proton-drive.svg" "${SRC_DIR}/proton-drive.svg"
-  fi
+	for size in 32x32 128x128 256x256; do
+		case "$size" in
+			32x32) ICON_FILE="${ICONS_DIR}/32x32.png" ;;
+			128x128) ICON_FILE="${ICONS_DIR}/128x128.png" ;;
+			256x256) ICON_FILE="${ICONS_DIR}/128x128@2x.png" ;;
+		esac
+		if [ -f "$ICON_FILE" ]; then
+			cp "$ICON_FILE" "${SRC_DIR}/icon-${size}.png"
+		fi
+	done
+	if [ -f "${ICONS_DIR}/proton-drive.svg" ]; then
+		cp "${ICONS_DIR}/proton-drive.svg" "${SRC_DIR}/proton-drive.svg"
+	fi
 fi
+
+SOURCE_ENTRIES=("proton-drive" "com.proton.drive.desktop")
+SHA256_ENTRIES=('SKIP' 'SKIP')
+
+for size in 32x32 128x128 256x256; do
+	if [ -f "${SRC_DIR}/icon-${size}.png" ]; then
+		SOURCE_ENTRIES+=("icon-${size}.png")
+		SHA256_ENTRIES+=('SKIP')
+	fi
+done
+
+if [ -f "${SRC_DIR}/proton-drive.svg" ]; then
+	SOURCE_ENTRIES+=("proton-drive.svg")
+	SHA256_ENTRIES+=('SKIP')
+fi
+
+SOURCE_LINE="source=(${SOURCE_ENTRIES[*]})"
+SHA256_LINE="sha256sums=(${SHA256_ENTRIES[*]})"
 
 cat > "${WORK_DIR}/PKGBUILD" <<PKGBUILD
 pkgname=proton-drive
@@ -64,22 +82,22 @@ provides=('proton-drive')
 conflicts=('proton-drive-bin')
 replaces=('proton-drive-bin')
 options=('!strip')
-source=("proton-drive" "com.proton.drive.desktop")
-sha256sums=('SKIP' 'SKIP')
+${SOURCE_LINE}
+${SHA256_LINE}
 
 package() {
-  install -Dm755 "\${srcdir}/proton-drive" "\${pkgdir}/usr/bin/proton-drive"
-  install -Dm644 "\${srcdir}/com.proton.drive.desktop" "\${pkgdir}/usr/share/applications/com.proton.drive.desktop"
+	install -Dm755 "\${srcdir}/proton-drive" "\${pkgdir}/usr/bin/proton-drive"
+	install -Dm644 "\${srcdir}/com.proton.drive.desktop" "\${pkgdir}/usr/share/applications/com.proton.drive.desktop"
 
-  for size in 32x32 128x128 256x256; do
-    if [ -f "\${srcdir}/icon-\${size}.png" ]; then
-      install -Dm644 "\${srcdir}/icon-\${size}.png" "\${pkgdir}/usr/share/icons/hicolor/\${size}/apps/com.proton.drive.png"
-    fi
-  done
+	for size in 32x32 128x128 256x256; do
+		if [ -f "\${srcdir}/icon-\${size}.png" ]; then
+			install -Dm644 "\${srcdir}/icon-\${size}.png" "\${pkgdir}/usr/share/icons/hicolor/\${size}/apps/com.proton.drive.png"
+		fi
+	done
 
-  if [ -f "\${srcdir}/proton-drive.svg" ]; then
-    install -Dm644 "\${srcdir}/proton-drive.svg" "\${pkgdir}/usr/share/icons/hicolor/scalable/apps/com.proton.drive.svg"
-  fi
+	if [ -f "\${srcdir}/proton-drive.svg" ]; then
+		install -Dm644 "\${srcdir}/proton-drive.svg" "\${pkgdir}/usr/share/icons/hicolor/scalable/apps/com.proton.drive.svg"
+	fi
 }
 PKGBUILD
 
@@ -109,9 +127,9 @@ su builder -c "makepkg --nodeps --skipinteg --noconfirm -f"
 
 PKG_FILE=$(ls "${OUTPUT_DIR}"/*.pkg.tar.zst 2>/dev/null | head -1)
 if [ -n "$PKG_FILE" ]; then
-  echo "Built: ${PKG_FILE}"
-  ls -la "${PKG_FILE}"
+	echo "Built: ${PKG_FILE}"
+	ls -la "${PKG_FILE}"
 else
-  echo "ERROR: No .pkg.tar.zst found in ${OUTPUT_DIR}"
-  exit 1
+	echo "ERROR: No .pkg.tar.zst found in ${OUTPUT_DIR}"
+	exit 1
 fi

--- a/scripts/ci/build-aur-package.sh
+++ b/scripts/ci/build-aur-package.sh
@@ -1,12 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-AUR_TARGET="${1:-arch}"
+AUR_TARGET="${1:-arch-native}"
 VERSION="${2:-1.3.2}"
 BINARY_PATH="${3:-src-tauri/target/release/proton-drive}"
-WRAPPER_PATH="${4:-aur/proton-drive.wrapper}"
-ICONS_DIR="${5:-src-tauri/icons}"
-REPO_ROOT="${6:-.}"
+ICONS_DIR="${4:-src-tauri/icons}"
+REPO_ROOT="${5:-.}"
 OUTPUT_DIR="/tmp/aur-output"
 
 mkdir -p "$OUTPUT_DIR"
@@ -19,8 +18,6 @@ SRC_DIR="${WORK_DIR}/src"
 mkdir -p "$SRC_DIR"
 cp "$BINARY_PATH" "${SRC_DIR}/proton-drive"
 chmod 755 "${SRC_DIR}/proton-drive"
-cp "$WRAPPER_PATH" "${SRC_DIR}/proton-drive.wrapper"
-chmod 755 "${SRC_DIR}/proton-drive.wrapper"
 
 cat > "${SRC_DIR}/com.proton.drive.desktop" <<DESKTOP
 [Desktop Entry]
@@ -54,24 +51,24 @@ if [ -d "$ICONS_DIR" ]; then
 fi
 
 cat > "${WORK_DIR}/PKGBUILD" <<PKGBUILD
-pkgname=proton-drive-bin
+pkgname=proton-drive
 pkgver=${VERSION}
 pkgrel=1
 pkgdesc="Unofficial Linux desktop client for Proton Drive, built with Tauri"
 arch=('x86_64')
 url="https://github.com/DonnieDice/protondrive-linux"
 license=('AGPL-3.0-only')
-depends=('webkit2gtk-4.1' 'gtk3' 'libayatana-appindicator')
+depends=('webkit2gtk-4.1' 'gtk3' 'libayatana-appindicator' 'openssl' 'libsoup3' 'librsvg')
+makedepends=('cargo' 'rust' 'nodejs' 'npm' 'git' 'pkg-config' 'patch')
 provides=('proton-drive')
-conflicts=('proton-drive')
+conflicts=('proton-drive-bin')
+replaces=('proton-drive-bin')
 options=('!strip')
-source=("proton-drive" "proton-drive.wrapper" "com.proton.drive.desktop")
-sha256sums=('SKIP' 'SKIP' 'SKIP')
+source=("proton-drive" "com.proton.drive.desktop")
+sha256sums=('SKIP' 'SKIP')
 
 package() {
-  install -dm755 "\${pkgdir}/usr/lib/proton-drive"
-  install -Dm755 "\${srcdir}/proton-drive" "\${pkgdir}/usr/lib/proton-drive/proton-drive.bin"
-  install -Dm755 "\${srcdir}/proton-drive.wrapper" "\${pkgdir}/usr/bin/proton-drive"
+  install -Dm755 "\${srcdir}/proton-drive" "\${pkgdir}/usr/bin/proton-drive"
   install -Dm644 "\${srcdir}/com.proton.drive.desktop" "\${pkgdir}/usr/share/applications/com.proton.drive.desktop"
 
   for size in 32x32 128x128 256x256; do
@@ -90,7 +87,6 @@ BUILD_DIR="${WORK_DIR}/build"
 mkdir -p "$BUILD_DIR"
 
 ln -sf "${SRC_DIR}/proton-drive" "${BUILD_DIR}/proton-drive"
-ln -sf "${SRC_DIR}/proton-drive.wrapper" "${BUILD_DIR}/proton-drive.wrapper"
 ln -sf "${SRC_DIR}/com.proton.drive.desktop" "${BUILD_DIR}/com.proton.drive.desktop"
 
 if [ -f "${SRC_DIR}/icon-32x32.png" ]; then ln -sf "${SRC_DIR}/icon-32x32.png" "${BUILD_DIR}/icon-32x32.png"; fi
@@ -106,10 +102,10 @@ chown -R builder:builder "$WORK_DIR"
 cd "$BUILD_DIR"
 
 BUILDDIR="${WORK_DIR}/makepkg-builddir" \
-  PKGDEST="$OUTPUT_DIR" \
-  SRCDEST="${WORK_DIR}/makepkg-srcdest" \
-  SRCPKGDEST="${WORK_DIR}/makepkg-srcpkgdest" \
-  su builder -c "makepkg --nodeps --skipinteg --noconfirm -f"
+PKGDEST="$OUTPUT_DIR" \
+SRCDEST="${WORK_DIR}/makepkg-srcdest" \
+SRCPKGDEST="${WORK_DIR}/makepkg-srcpkgdest" \
+su builder -c "makepkg --nodeps --skipinteg --noconfirm -f"
 
 PKG_FILE=$(ls "${OUTPUT_DIR}"/*.pkg.tar.zst 2>/dev/null | head -1)
 if [ -n "$PKG_FILE" ]; then


### PR DESCRIPTION
## Summary

- Convert AUR package from `proton-drive-bin` (AppImage wrapper) to `proton-drive` (native Arch build compiling against system WebKitGTK)
- Simplify runtime workarounds: drop `GDK_GL=disable`, `LIBGL_ALWAYS_SOFTWARE=1`, `GSK_RENDERER=cairo`; keep sandbox disable and IPInt WASM disable only
- Fix version to 1.4.0, fix icons not included in CI package, fix PKGBUILD source directory naming, add `python` to makedepends
- Align workflow name (`Build AUR Arch Native`) with release gate expected name
- Fix publish-aur.yml to wait for source tarball and fail on timeout

## Smoke Test Results

- CI build: **passed**
- Package: `proton-drive-1.4.0-1-x86_64.pkg.tar.zst`
- Install: **success** (replaces `proton-drive-bin`)
- Icons: 32x32, 128x128, 256x256 PNGs + SVG all installed correctly
- App launch: **login page renders**, WebKitGTK webview functional, hardware rendering working