### PR TITLE
feat: add Alpine 3.22 APK build target

### DIFF
--- a/.github/workflows/build-apk.alpine.3.22.yml
+++ b/.github/workflows/build-apk.alpine.3.22.yml
@@ -1,0 +1,177 @@
+name: Build APK Alpine 3.22
+
+"on":
+  push:
+    branches:
+    - main
+    - dev
+    - alpha
+    tags:
+    - "v*"
+  workflow_dispatch:
+    inputs:
+      distro_patch:
+        description: "Distro patch name (e.g. alpine.3.22)"
+        required: false
+        default: "alpine.3.22"
+
+permissions:
+  contents: read
+
+env:
+  RUST_VERSION: stable
+  DISTRO_TYPE: apk
+  DISTRO_PATCH: ${{ github.event.inputs.distro_patch || 'alpine.3.22' }}
+  DISTRO_SUFFIX: alpine322
+
+jobs:
+  build-apk:
+    name: Alpine 3.22 APK
+    runs-on: ubuntu-latest
+    container:
+      image: alpine:3.22
+    timeout-minutes: 120
+    defaults:
+      run:
+        shell: /bin/sh -e {0}
+
+    steps:
+    - name: Install build dependencies
+      run: |
+        apk update
+        apk add \
+          bash git curl wget build-base file pkgconfig \
+          openssl-dev openssl-libs-static \
+          webkit2gtk-4.1-dev gtk+3.0-dev \
+          glib-dev gdk-pixbuf-dev harfbuzz-dev \
+          pango-dev cairo-dev \
+          wayland-dev zlib-dev libintl musl-dev \
+          libsoup3-dev libayatana-appindicator-dev \
+          patchelf nodejs npm \
+          python3 ca-certificates \
+          vips-dev libjpeg-turbo-dev giflib-dev
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Install Rust via rustup
+      run: |
+        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain "${RUST_VERSION}"
+        echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+        . "$HOME/.cargo/env"
+        rustc --version
+        cargo --version
+
+    - name: Cache Cargo
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          src-tauri/target/
+        key: apk-alpine322-cargo-${{ hashFiles('src-tauri/Cargo.lock') }}
+        restore-keys: apk-alpine322-cargo-
+
+    - name: Configure cargo for musl linking
+      run: |
+        mkdir -p .cargo
+        cat > .cargo/config.toml <<'EOF'
+        [target.x86_64-unknown-linux-musl]
+        linker = "gcc"
+        rustflags = ["-C", "target-feature=-crt-static"]
+        EOF
+        echo "Created .cargo/config.toml:"
+        cat .cargo/config.toml
+
+    - name: Clone WebClients
+      run: |
+        git clone --depth=1 --single-branch --branch main https://github.com/ProtonMail/WebClients.git WebClients
+
+    - name: Apply distro patch
+      run: |
+        PATCH_FILE="patches/apk/${DISTRO_PATCH}.patch"
+        if [ -f "$PATCH_FILE" ]; then
+          if git apply --reverse --check "$PATCH_FILE" 2>/dev/null; then
+            echo "Patch already applied: $PATCH_FILE"
+          else
+            git apply --check "$PATCH_FILE"
+            git apply "$PATCH_FILE"
+            echo "Applied $PATCH_FILE"
+          fi
+        else
+          echo "WARNING: $PATCH_FILE not found, building without distro patch"
+        fi
+
+    - name: Build APK
+      run: |
+        if [ -f "$HOME/.cargo/env" ]; then . "$HOME/.cargo/env"; fi
+        export PKG_CONFIG_ALLOW_CROSS=1
+        export PKG_CONFIG_PATH="/usr/lib/pkgconfig:/usr/share/pkgconfig"
+        scripts/build-webclients.sh
+        VERSION=$(node -p "require('./package.json').version")
+        sed -i "s/\"version\": \"[^\"]*\"/\"version\": \"$VERSION\"/" src-tauri/tauri.conf.json
+        sed -i "0,/^version = \"[^\"]*\"/s//version = \"$VERSION\"/" src-tauri/Cargo.toml
+        npm install
+        cd src-tauri && cargo build --release --verbose
+
+    - name: Package APK
+      run: |
+        VERSION=$(node -p "require('./package.json').version")
+        ARCH=x86_64
+        BINARY=src-tauri/target/release/proton-drive
+        if [ ! -f "$BINARY" ]; then
+          echo "ERROR: binary not found at $BINARY"
+          exit 1
+        fi
+        APK_STAGING="/tmp/proton-drive-apk"
+        rm -rf "$APK_STAGING"
+        mkdir -p "$APK_STAGING/usr/bin"
+        mkdir -p "$APK_STAGING/usr/share/applications"
+        mkdir -p "$APK_STAGING/usr/share/icons/hicolor/32x32/apps"
+        mkdir -p "$APK_STAGING/usr/share/icons/hicolor/128x128/apps"
+        mkdir -p "$APK_STAGING/usr/share/icons/hicolor/128x128@2/apps"
+        mkdir -p "$APK_STAGING/usr/share/icons/hicolor/scalable/apps"
+
+        cp "$BINARY" "$APK_STAGING/usr/bin/proton-drive"
+        strip "$APK_STAGING/usr/bin/proton-drive" 2>/dev/null || true
+        cp src-tauri/linux/proton-drive.desktop "$APK_STAGING/usr/share/applications/"
+        cp src-tauri/icons/32x32.png "$APK_STAGING/usr/share/icons/hicolor/32x32/apps/proton-drive.png"
+        cp src-tauri/icons/128x128.png "$APK_STAGING/usr/share/icons/hicolor/128x128/apps/proton-drive.png"
+        cp src-tauri/icons/128x128@2x.png "$APK_STAGING/usr/share/icons/hicolor/128x128@2/apps/proton-drive.png"
+        cp src-tauri/icons/proton-drive.svg "$APK_STAGING/usr/share/icons/hicolor/scalable/apps/proton-drive.svg"
+
+        cat > "$APK_STAGING/APKBUILD" <<EOF
+        pkgname=proton-drive
+        pkgver=${VERSION}
+        pkgrel=0
+        pkgdesc="Proton Drive desktop client"
+        url="https://github.com/DonnieDice/protondrive-linux"
+        arch="x86_64"
+        license="AGPL-3.0"
+        depends="webkit2gtk-4.1 gtk+3.0"
+        options="!check"
+        package() {
+          install -Dm755 usr/bin/proton-drive "\$pkgdir"/usr/bin/proton-drive
+          install -Dm644 usr/share/applications/proton-drive.desktop "\$pkgdir"/usr/share/applications/proton-drive.desktop
+          install -Dm644 usr/share/icons/hicolor/32x32/apps/proton-drive.png "\$pkgdir"/usr/share/icons/hicolor/32x32/apps/proton-drive.png
+          install -Dm644 usr/share/icons/hicolor/128x128/apps/proton-drive.png "\$pkgdir"/usr/share/icons/hicolor/128x128/apps/proton-drive.png
+          install -Dm644 usr/share/icons/hicolor/128x128@2/apps/proton-drive.png "\$pkgdir"/usr/share/icons/hicolor/128x128@2/apps/proton-drive.png
+          install -Dm644 usr/share/icons/hicolor/scalable/apps/proton-drive.svg "\$pkgdir"/usr/share/icons/hicolor/scalable/apps/proton-drive.svg
+        }
+        EOF
+
+        ARTIFACT_DIR="/tmp/apk-artifact"
+        rm -rf "$ARTIFACT_DIR"
+        mkdir -p "$ARTIFACT_DIR"
+        tar -C "$APK_STAGING" -czf "$ARTIFACT_DIR/proton-drive_${VERSION}_${DISTRO_SUFFIX}_amd64.apk.tar.gz" .
+        echo "Packaged: $ARTIFACT_DIR/proton-drive_${VERSION}_${DISTRO_SUFFIX}_amd64.apk.tar.gz"
+
+    - name: Upload APK artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: apk-package-alpine322
+        path: /tmp/apk-artifact/proton-drive_*_alpine322_amd64.apk.tar.gz
+        if-no-files-found: error
+        retention-days: 30

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,24 +62,24 @@ jobs:
           script: |
             const sha = context.sha;
             console.log(`Waiting for builds for SHA: ${sha}`);
-        const expectedWorkflows = [
-          'Build AppImage',
-          'Build Flatpak',
-          'Build Flatpak GNOME 49',
-          'Build Snap',
-          'Build Snap Core26',
-          'Build AUR Arch Native',
-          'Build DEB Debian 12',
-          'Build DEB Debian 13',
-          'Build DEB Ubuntu 24.04',
-          'Build DEB Ubuntu 26.04',
-          'Build RPM Fedora 43',
-          'Build RPM Fedora 44',
-          'Build RPM EL10',
-          'Build RPM openSUSE Tumbleweed',
-  'Build APK Alpine 3.20',
-  'Build APK Alpine 3.22',
-];
+            const expectedWorkflows = [
+              'Build AppImage',
+              'Build Flatpak',
+              'Build Flatpak GNOME 49',
+              'Build Snap',
+              'Build Snap Core26',
+              'Build AUR Arch Native',
+              'Build DEB Debian 12',
+              'Build DEB Debian 13',
+              'Build DEB Ubuntu 24.04',
+              'Build DEB Ubuntu 26.04',
+              'Build RPM Fedora 43',
+              'Build RPM Fedora 44',
+              'Build RPM EL10',
+              'Build RPM openSUSE Tumbleweed',
+              'Build APK Alpine 3.20',
+              'Build APK Alpine 3.22',
+            ];
             await new Promise(resolve => setTimeout(resolve, 30000));
             const maxAttempts = 75;
             for (let i = 0; i < maxAttempts; i++) {
@@ -152,15 +152,15 @@ jobs:
           workflow_conclusion: success
           if_no_artifact_found: fail
 
-- name: Download AUR artifact
-  uses: dawidd6/action-download-artifact@v6
-  with:
-    workflow: build-aur.yml
-    name: aur-arch-native
-    path: artifacts/aur
-    commit: ${{ github.sha }}
-    workflow_conclusion: success
-    if_no_artifact_found: fail
+      - name: Download AUR artifact
+        uses: dawidd6/action-download-artifact@v6
+        with:
+          workflow: build-aur.yml
+          name: aur-arch-native
+          path: artifacts/aur
+          commit: ${{ github.sha }}
+          workflow_conclusion: success
+          if_no_artifact_found: fail
 
       - name: Download DEB Debian 12 artifact
         uses: dawidd6/action-download-artifact@v6
@@ -242,35 +242,35 @@ jobs:
           workflow_conclusion: success
           if_no_artifact_found: fail
 
-    - name: Download Snap Core26 artifact
-      uses: dawidd6/action-download-artifact@v6
-      with:
-        workflow: build-snap.core26.yml
-        name: snap-package-core26
-        path: artifacts/snap-core26
-        commit: ${{ github.sha }}
-        workflow_conclusion: success
-        if_no_artifact_found: fail
+      - name: Download Snap Core26 artifact
+        uses: dawidd6/action-download-artifact@v6
+        with:
+          workflow: build-snap.core26.yml
+          name: snap-package-core26
+          path: artifacts/snap-core26
+          commit: ${{ github.sha }}
+          workflow_conclusion: success
+          if_no_artifact_found: fail
 
-- name: Download APK Alpine 3.20 artifact
-  uses: dawidd6/action-download-artifact@v6
-  with:
-    workflow: build-apk.alpine.3.20.yml
-    name: apk-package-alpine320
-    path: artifacts/apk-alpine320
-    commit: ${{ github.sha }}
-    workflow_conclusion: success
-    if_no_artifact_found: fail
+      - name: Download APK Alpine 3.20 artifact
+        uses: dawidd6/action-download-artifact@v6
+        with:
+          workflow: build-apk.alpine.3.20.yml
+          name: apk-package-alpine320
+          path: artifacts/apk-alpine320
+          commit: ${{ github.sha }}
+          workflow_conclusion: success
+          if_no_artifact_found: fail
 
-- name: Download APK Alpine 3.22 artifact
-  uses: dawidd6/action-download-artifact@v6
-  with:
-    workflow: build-apk.alpine.3.22.yml
-    name: apk-package-alpine322
-    path: artifacts/apk-alpine322
-    commit: ${{ github.sha }}
-    workflow_conclusion: success
-    if_no_artifact_found: fail
+      - name: Download APK Alpine 3.22 artifact
+        uses: dawidd6/action-download-artifact@v6
+        with:
+          workflow: build-apk.alpine.3.22.yml
+          name: apk-package-alpine322
+          path: artifacts/apk-alpine322
+          commit: ${{ github.sha }}
+          workflow_conclusion: success
+          if_no_artifact_found: fail
 
       - name: Prepare release files
         run: |
@@ -285,21 +285,21 @@ jobs:
               rpm-fedora44/*)
                 dest="release/${name%.rpm}-fedora44.rpm"
                 ;;
-      rpm-el10/*)
-        dest="release/${name%.rpm}-el10.rpm"
-        ;;
-          rpm-opensuse-tumbleweed/*)
-            dest="release/${name%.rpm}-opensuse-tumbleweed.rpm"
-            ;;
-    apk-alpine320/*)
-      dest="release/${name}"
-      ;;
-    apk-alpine322/*)
-      dest="release/${name}"
-      ;;
-          *)
-                dest="release/${name}"
-                ;;
+            rpm-el10/*)
+              dest="release/${name%.rpm}-el10.rpm"
+              ;;
+            rpm-opensuse-tumbleweed/*)
+              dest="release/${name%.rpm}-opensuse-tumbleweed.rpm"
+              ;;
+            apk-alpine320/*)
+              dest="release/${name}"
+              ;;
+            apk-alpine322/*)
+              dest="release/${name}"
+              ;;
+            *)
+              dest="release/${name}"
+              ;;
             esac
             cp "$src" "$dest"
           done
@@ -338,9 +338,9 @@ jobs:
           | RPM (Fedora 43) | \`proton-drive-*-fedora43.rpm\` | Fedora 43+ |
           | RPM (Fedora 44) | \`proton-drive-*-fedora44.rpm\` | Fedora 44+ |
           | RPM (EL10) | \`proton-drive-*-el10.rpm\` | RHEL 10 / Alma 10 / CentOS Stream 10 |
-| RPM (openSUSE Tumbleweed) | \`proton-drive-*-opensuse-tumbleweed.rpm\` | openSUSE Tumbleweed (rolling) |
-| APK (Alpine 3.20) | \`proton-drive_*_alpine320_amd64.apk.tar.gz\` | Alpine 3.20 (musl) |
-| APK (Alpine 3.22) | \`proton-drive_*_alpine322_amd64.apk.tar.gz\` | Alpine 3.22 (musl) |
+          | RPM (openSUSE Tumbleweed) | \`proton-drive-*-opensuse-tumbleweed.rpm\` | openSUSE Tumbleweed (rolling) |
+          | APK (Alpine 3.20) | \`proton-drive_*_alpine320_amd64.apk.tar.gz\` | Alpine 3.20 (musl) |
+          | APK (Alpine 3.22) | \`proton-drive_*_alpine322_amd64.apk.tar.gz\` | Alpine 3.22 (musl) |
 
           ## Installation
 
@@ -370,25 +370,25 @@ jobs:
           sudo apt install ./proton-drive_*.deb
           \`\`\`
 
-### Fedora/RHEL
-\`\`\`bash
-sudo dnf install ./proton-drive-*.rpm
-\`\`\`
+          ### Fedora/RHEL
+          \`\`\`bash
+          sudo dnf install ./proton-drive-*.rpm
+          \`\`\`
 
-### openSUSE Tumbleweed
-\`\`\`bash
-sudo zypper install ./proton-drive-*-opensuse-tumbleweed.rpm
-\`\`\`
+          ### openSUSE Tumbleweed
+          \`\`\`bash
+          sudo zypper install ./proton-drive-*-opensuse-tumbleweed.rpm
+          \`\`\`
 
-### Alpine 3.20
-\`\`\`bash
-sudo apk add ./proton-drive_*_alpine320_amd64.apk.tar.gz
-\`\`\`
+          ### Alpine 3.20
+          \`\`\`bash
+          sudo tar -C / -xzf ./proton-drive_*_alpine320_amd64.apk.tar.gz
+          \`\`\`
 
-### Alpine 3.22
-\`\`\`bash
-sudo apk add ./proton-drive_*_alpine322_amd64.apk.tar.gz
-\`\`\`
+          ### Alpine 3.22
+          \`\`\`bash
+          sudo tar -C / -xzf ./proton-drive_*_alpine322_amd64.apk.tar.gz
+          \`\`\`
 
           ## Checksums
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,8 +77,9 @@ jobs:
           'Build RPM Fedora 44',
           'Build RPM EL10',
           'Build RPM openSUSE Tumbleweed',
-          'Build APK Alpine 3.20',
-        ];
+  'Build APK Alpine 3.20',
+  'Build APK Alpine 3.22',
+];
             await new Promise(resolve => setTimeout(resolve, 30000));
             const maxAttempts = 75;
             for (let i = 0; i < maxAttempts; i++) {
@@ -251,15 +252,25 @@ jobs:
         workflow_conclusion: success
         if_no_artifact_found: fail
 
-    - name: Download APK Alpine 3.20 artifact
-      uses: dawidd6/action-download-artifact@v6
-      with:
-        workflow: build-apk.alpine.3.20.yml
-        name: apk-package-alpine320
-        path: artifacts/apk-alpine320
-        commit: ${{ github.sha }}
-        workflow_conclusion: success
-        if_no_artifact_found: fail
+- name: Download APK Alpine 3.20 artifact
+  uses: dawidd6/action-download-artifact@v6
+  with:
+    workflow: build-apk.alpine.3.20.yml
+    name: apk-package-alpine320
+    path: artifacts/apk-alpine320
+    commit: ${{ github.sha }}
+    workflow_conclusion: success
+    if_no_artifact_found: fail
+
+- name: Download APK Alpine 3.22 artifact
+  uses: dawidd6/action-download-artifact@v6
+  with:
+    workflow: build-apk.alpine.3.22.yml
+    name: apk-package-alpine322
+    path: artifacts/apk-alpine322
+    commit: ${{ github.sha }}
+    workflow_conclusion: success
+    if_no_artifact_found: fail
 
       - name: Prepare release files
         run: |
@@ -280,9 +291,12 @@ jobs:
           rpm-opensuse-tumbleweed/*)
             dest="release/${name%.rpm}-opensuse-tumbleweed.rpm"
             ;;
-          apk-alpine320/*)
-            dest="release/${name}"
-            ;;
+    apk-alpine320/*)
+      dest="release/${name}"
+      ;;
+    apk-alpine322/*)
+      dest="release/${name}"
+      ;;
           *)
                 dest="release/${name}"
                 ;;
@@ -326,6 +340,7 @@ jobs:
           | RPM (EL10) | \`proton-drive-*-el10.rpm\` | RHEL 10 / Alma 10 / CentOS Stream 10 |
 | RPM (openSUSE Tumbleweed) | \`proton-drive-*-opensuse-tumbleweed.rpm\` | openSUSE Tumbleweed (rolling) |
 | APK (Alpine 3.20) | \`proton-drive_*_alpine320_amd64.apk.tar.gz\` | Alpine 3.20 (musl) |
+| APK (Alpine 3.22) | \`proton-drive_*_alpine322_amd64.apk.tar.gz\` | Alpine 3.22 (musl) |
 
           ## Installation
 
@@ -368,6 +383,11 @@ sudo zypper install ./proton-drive-*-opensuse-tumbleweed.rpm
 ### Alpine 3.20
 \`\`\`bash
 sudo apk add ./proton-drive_*_alpine320_amd64.apk.tar.gz
+\`\`\`
+
+### Alpine 3.22
+\`\`\`bash
+sudo apk add ./proton-drive_*_alpine322_amd64.apk.tar.gz
 \`\`\`
 
           ## Checksums

--- a/docs/new-build-checklist.md
+++ b/docs/new-build-checklist.md
@@ -133,25 +133,35 @@ repos, and the compatibility map can lag behind reality.
 
 ## Step 7: Push and Validate
 
-- [ ] Commit all changes to `dev`.
-- [ ] Push `dev` to remote.
-- [ ] Confirm the new GitHub Actions workflow triggers and passes.
+- [ ] Push the feature branch to remote.
+- [ ] Open a pull request against `dev`.
+- [ ] Wait for Qodo review bot to check the PR.
+- [ ] Fix any review issues and push again until Qodo reviews pass.
+- [ ] Merge the PR into `dev`.
+- [ ] Confirm the new GitHub Actions workflow triggers and passes on `dev`.
 - [ ] Download the workflow artifact.
 - [ ] Install and test the artifact on the target host (runtime smoke test).
-  - The app must launch and display the Proton Drive login page.
-  - The WebKitGTK webview must render without a white screen or crash.
-  - If the app fails to render, try the WebKitGTK environment workarounds
-    from the README: `WEBKIT_DISABLE_DMABUF_RENDERER=1
-    WEBKIT_DISABLE_COMPOSITING_MODE=1`.
+- The app must launch and display the Proton Drive login page.
+- The WebKitGTK webview must render without a white screen or crash.
+- If the app fails to render, try the WebKitGTK environment workarounds
+from the README: `WEBKIT_DISABLE_DMABUF_RENDERER=1
+WEBKIT_DISABLE_COMPOSITING_MODE=1`.
 
 ## Step 8: Promote to Release-Gated (After Smoke Test Passes)
 
 - [ ] Update `packaging/compatibility-map.yml`: change status to
-  `release-gated`, set `runtime_smoke.status: pass`, add evidence.
+`release-gated`, set `runtime_smoke.status: pass`, add evidence.
 - [ ] Update `docs/packaging.md`: move the target to the release-gated table.
 - [ ] Update `patches/README.md`: move the patch to the release-gated list.
 - [ ] Update `docs/release-checklist.md` if needed.
-- [ ] Commit and push the promotion to `dev`.
+- [ ] Commit and push the promotion to the feature branch (or `dev` if merged).
+
+## Step 9: Release Deployment
+
+- [ ] Confirm `dev` CI is green after all feature PR merges.
+- [ ] Merge `dev` into `main` directly.
+- [ ] Push `main`.
+- [ ] Tag the release from `main`.
 
 ## Notes and Lessons Learned
 

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -90,7 +90,7 @@ described above. Both must pass for a target to be `release-gated`.
 | Package target | glibc gate | WebKitGTK gate | Workflow / artifact | Patch | Runtime smoke | Covered systems / rule | Next action |
 |----------------|-----------|----------------|---------------------|-------|---------------|------------------------|-------------|
 | openSUSE Leap 16 RPM | pass | pass | none yet / `rpm-package-opensuse-leap16` planned | `rpm/opensuse.leap.16.patch` | no release artifact | openSUSE Leap 16 | add zypper workflow, release artifact, and runtime smoke |
-| Alpine 3.22 APK | musl pass | pass | none yet / `apk-package-alpine322` planned | `apk/alpine.3.22.patch` | no release artifact | Alpine 3.22 musl; glibc artifacts are not compatible | add APK/musl workflow, release artifact, and runtime smoke |
+| Alpine 3.22 APK | musl pass | pass | `build-apk.alpine.3.22.yml` / `apk-package-alpine322` | `apk/alpine.3.22.patch` | no release artifact | Alpine 3.22 musl; glibc artifacts are not compatible | validate musl runtime install and login smoke test |
 | Alpine 3.23 APK | musl pass | pass | none yet / `apk-package-alpine323` planned | `apk/alpine.3.23.patch` | no release artifact | Alpine 3.23 musl; glibc artifacts are not compatible | add APK/musl workflow, release artifact, and runtime smoke |
 
 ### Roadmap targets (no patch yet)
@@ -229,10 +229,24 @@ asset path fixes, and Webpack SRI disabled for Drive, Account, and Verify.
 Release flow:
 
 ```text
-dev -> active build and workflow fixes
+feat/<target> -> feature branch for new package target work
+dev -> active build and workflow fixes; integration branch for feature PRs
 main -> stable release source
 tags -> release artifacts
 ```
+
+### Feature Branch Workflow
+
+New package targets follow this branch lifecycle:
+
+1. **Create feature branch** from `dev`: `feat/<target>` (e.g., `feat/alpine-3.22-apk`).
+2. **Do all work on the feature branch**: patch, workflow, build script, docs, compatibility map.
+3. **Push feature branch** and open a pull request against `dev`.
+4. **Qodo review bot** checks the PR. Fix any issues and push again until Qodo reviews clean.
+5. **Merge PR into `dev`** once reviews pass.
+6. **Verify CI is green on `dev`** after the merge.
+7. **Merge `dev` into `main`** for release deployment.
+8. **Tag the release** from `main`.
 
 Do not cut a stable release directly from `dev`. Once `dev` is green, merge the
 tested commits into `main`, push `main`, then create or update the release tag
@@ -247,7 +261,7 @@ Release checklist:
   `packaging/compatibility-map.yml`.
 - `main` contains only the tested dev commits intended for release.
 - Release tag points at `main`, not `dev`.
-- GitHub release contains all 14 release-gated artifacts plus `SHA256SUMS`.
+- GitHub release contains all 15 release-gated artifacts plus `SHA256SUMS`.
 
 Promotion checklist for roadmap targets:
 

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -37,13 +37,25 @@ Use this checklist before every release deployment.
   - [ ] Snap workflows are passing.
 - [ ] AUR workflow is passing.
 - [ ] APK Alpine 3.20 workflow is passing.
+- [ ] APK Alpine 3.22 workflow is passing.
 - [ ] Release workflow is passing.
 
-- [ ] Merge `dev` to `main` directly.
-  - [ ] Confirm `dev` contains only commits intended for the release.
-  - [ ] Merge `dev` into `main` directly.
-  - [ ] Never open a pull request for the release merge.
-  - [ ] Push `main` after the direct merge.
+- [ ] Merge `dev` to `main` for release.
+- [ ] Confirm `dev` CI is green after all feature PR merges.
+- [ ] Merge `dev` into `main` directly.
+- [ ] Never open a pull request for the release merge.
+- [ ] Push `main` after the direct merge.
+
+## Feature Branch Checklist
+
+New package targets use feature branches:
+
+- [ ] Create feature branch `feat/<target>` from `dev`.
+- [ ] Do all patch, workflow, build script, doc, and compatibility map work on the feature branch.
+- [ ] Push feature branch and open PR against `dev`.
+- [ ] Qodo review bot checks the PR. Fix issues and push until reviews pass.
+- [ ] Merge PR into `dev`.
+- [ ] Verify CI is green on `dev` after merge.
 
 ## Final Release Gate
 

--- a/packaging/compatibility-map.yml
+++ b/packaging/compatibility-map.yml
@@ -311,21 +311,24 @@ roadmap_patch_ready:
         rustflags = ["-C", "target-feature=-crt-static"]
       supports:
       - alpine-3.20
-    alpine322:
-      status: roadmap-patch-ready
-      gates:
-        glibc: musl-pass
-        webkitgtk: pass
-      workflow: null
-      build_container: alpine:3.22
-      release_label: alpine322
-      artifact_name: apk-package-alpine322
-      patch: alpine.3.22
-      supports:
-      - alpine-3.22
-      before_release_gate:
-      - add APK packaging workflow
-      - validate musl runtime install and login smoke test
+  alpine322:
+    status: roadmap-patch-ready
+    gates:
+      glibc: musl-pass
+      webkitgtk: pass
+    workflow: .github/workflows/build-apk.alpine.3.22.yml
+    build_container: alpine:3.22
+    release_label: alpine322
+    artifact_name: apk-package-alpine322
+    patch: alpine.3.22
+    cargo_config: |
+      [target.x86_64-unknown-linux-musl]
+      linker = "gcc"
+      rustflags = ["-C", "target-feature=-crt-static"]
+    supports:
+    - alpine-3.22
+    before_release_gate:
+    - validate musl runtime install and login smoke test
     alpine323:
       status: roadmap-patch-ready
       gates:

--- a/patches/README.md
+++ b/patches/README.md
@@ -75,7 +75,7 @@ are not release-gated yet.
 |-------|--------|----------------------------|
 | `rpm/opensuse.tumbleweed.patch` | openSUSE Tumbleweed | zypper RPM workflow, artifact upload, runtime smoke test |
 | `rpm/opensuse.leap.16.patch` | openSUSE Leap 16 | zypper RPM workflow, artifact upload, runtime smoke test |
-| `apk/alpine.3.22.patch` | Alpine 3.22 musl | APK packaging workflow, artifact upload, musl runtime smoke test |
+| `apk/alpine.3.22.patch` | Alpine 3.22 musl | musl runtime install and login smoke test |
 | `apk/alpine.3.23.patch` | Alpine 3.23 musl | APK packaging workflow, artifact upload, musl runtime smoke test |
 
 No optional desktop-runtime variants or older GNOME Flatpak patches are

--- a/scripts/ci/build-alpine-322-apk.sh
+++ b/scripts/ci/build-alpine-322-apk.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/ci/build-alpine-322-apk.sh
+
+Build the Proton Drive APK package for Alpine 3.22 musl using the
+alpine.3.22 patch.
+
+Environment:
+  OUTPUT_DIR  Optional destination directory for the APK artifact.
+              Defaults to /tmp/protondrive-alpine322-apk
+EOF
+}
+
+if [ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]; then
+  usage
+  exit 0
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$(dirname "$SCRIPT_DIR")")"
+PATCH_FILE="$REPO_ROOT/patches/apk/alpine.3.22.patch"
+OUTPUT_DIR="${OUTPUT_DIR:-/tmp/protondrive-alpine322-apk}"
+WORK_ROOT="$(mktemp -d -t protondrive-alpine322-XXXXXX)"
+WORK_TREE="$WORK_ROOT/protondrive-linux"
+
+cleanup() {
+  rm -rf "$WORK_ROOT"
+}
+trap cleanup EXIT
+
+if [ ! -f "$PATCH_FILE" ]; then
+  echo "ERROR: missing patch file: $PATCH_FILE" >&2
+  exit 1
+fi
+
+mkdir -p "$OUTPUT_DIR"
+
+echo "Creating clean worktree..."
+git -C "$REPO_ROOT" worktree add --detach "$WORK_TREE" HEAD >/dev/null
+
+echo "Applying Alpine 3.22 patch..."
+cd "$WORK_TREE"
+git apply --check "$PATCH_FILE"
+git apply "$PATCH_FILE"
+
+echo "Building WebClients..."
+scripts/build-webclients.sh
+
+echo "Building binary..."
+if [ -f "$HOME/.cargo/env" ]; then
+  . "$HOME/.cargo/env"
+fi
+export PATH="$HOME/.cargo/bin:$PATH"
+cargo --version
+VERSION="$(node -p "require('./package.json').version")"
+sed -i "s/\"version\": \"[^\"]*\"/\"version\": \"$VERSION\"/" src-tauri/tauri.conf.json
+sed -i "0,/^version = \"[^\"]*\"/s//version = \"$VERSION\"/" src-tauri/Cargo.toml
+npm install
+npx tauri build --verbose
+
+echo "Packaging APK..."
+BINARY="src-tauri/target/release/proton-drive"
+if [ ! -f "$BINARY" ]; then
+  echo "ERROR: binary not found at $BINARY" >&2
+  exit 1
+fi
+
+APK_STAGING="$WORK_ROOT/apk-staging"
+mkdir -p "$APK_STAGING/usr/bin"
+mkdir -p "$APK_STAGING/usr/share/applications"
+mkdir -p "$APK_STAGING/usr/share/icons/hicolor/32x32/apps"
+mkdir -p "$APK_STAGING/usr/share/icons/hicolor/128x128/apps"
+mkdir -p "$APK_STAGING/usr/share/icons/hicolor/128x128@2/apps"
+mkdir -p "$APK_STAGING/usr/share/icons/hicolor/scalable/apps"
+
+cp "$BINARY" "$APK_STAGING/usr/bin/proton-drive"
+strip "$APK_STAGING/usr/bin/proton-drive" 2>/dev/null || true
+cp src-tauri/linux/proton-drive.desktop "$APK_STAGING/usr/share/applications/"
+cp src-tauri/icons/32x32.png "$APK_STAGING/usr/share/icons/hicolor/32x32/apps/proton-drive.png"
+cp src-tauri/icons/128x128.png "$APK_STAGING/usr/share/icons/hicolor/128x128/apps/proton-drive.png"
+cp src-tauri/icons/128x128@2x.png "$APK_STAGING/usr/share/icons/hicolor/128x128@2/apps/proton-drive.png"
+cp src-tauri/icons/proton-drive.svg "$APK_STAGING/usr/share/icons/hicolor/scalable/apps/proton-drive.svg"
+
+ARTIFACT_NAME="proton-drive_${VERSION}_alpine322_amd64.apk.tar.gz"
+tar -C "$APK_STAGING" -czf "$OUTPUT_DIR/$ARTIFACT_NAME" .
+
+echo "Built APK: $OUTPUT_DIR/$ARTIFACT_NAME"


### PR DESCRIPTION
## Summary

- Add Alpine 3.22 APK CI workflow (`build-apk.alpine.3.22.yml`) with alpine:3.22 container, rustup, `.cargo/config.toml` (gcc linker + crt-static disabled), `cargo build --release`, and APK packaging step
- Add local build script `scripts/ci/build-alpine-322-apk.sh`
- Integrate Alpine 3.22 APK into `release.yml` (expectedWorkflows, artifact download, filename handling, release notes, install instructions)
- Update `packaging/compatibility-map.yml`: set workflow, add cargo_config, update before_release_gate
- Update docs: `packaging.md`, `patches/README.md`, `release-checklist.md`
- Update `new-build-checklist.md` with feature branch workflow (branch off dev, PR to dev, Qodo review, merge dev to main)

## Compatibility Gates

- **musl**: pass (musl 1.2.5-r12 on Alpine 3.22)
- **WebKitGTK 4.1**: pass (v2.48.1 installed on Alpine 3.22 host)

## Next Steps

After merge to dev and CI green: download artifact, run smoke test on Alpine 3.22 host, promote to release-gated.