### PR TITLE
Add Alpine 3.22 APK to release deployment and bump to 1.4.2 (#63)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,6 +78,7 @@ jobs:
               'Build RPM EL10',
               'Build RPM openSUSE Tumbleweed',
               'Build APK Alpine 3.20',
+              'Build APK Alpine 3.22',
             ];
             await new Promise(resolve => setTimeout(resolve, 30000));
             const maxAttempts = 75;
@@ -261,6 +262,16 @@ jobs:
           workflow_conclusion: success
           if_no_artifact_found: fail
 
+      - name: Download APK Alpine 3.22 artifact
+        uses: dawidd6/action-download-artifact@v6
+        with:
+          workflow: build-apk.alpine.3.22.yml
+          name: apk-package-alpine322
+          path: artifacts/apk-alpine322
+          commit: ${{ github.sha }}
+          workflow_conclusion: success
+          if_no_artifact_found: fail
+
       - name: Prepare release files
         run: |
           mkdir -p release
@@ -281,6 +292,9 @@ jobs:
                 dest="release/${name%.rpm}-opensuse-tumbleweed.rpm"
                 ;;
               apk-alpine320/*)
+                dest="release/${name}"
+                ;;
+              apk-alpine322/*)
                 dest="release/${name}"
                 ;;
               *)
@@ -326,6 +340,7 @@ jobs:
           | RPM (EL10) | \`proton-drive-*-el10.rpm\` | RHEL 10 / Alma 10 / CentOS Stream 10 |
           | RPM (openSUSE Tumbleweed) | \`proton-drive-*-opensuse-tumbleweed.rpm\` | openSUSE Tumbleweed (rolling) |
           | APK (Alpine 3.20) | \`proton-drive_*_alpine320_amd64.apk.tar.gz\` | Alpine 3.20 (musl) |
+          | APK (Alpine 3.22) | \`proton-drive_*_alpine322_amd64.apk.tar.gz\` | Alpine 3.22 (musl) |
 
           ## Installation
 
@@ -368,6 +383,11 @@ jobs:
           ### Alpine 3.20
           \`\`\`bash
           sudo apk add ./proton-drive_*_alpine320_amd64.apk.tar.gz
+          \`\`\`
+
+          ### Alpine 3.22
+          \`\`\`bash
+          sudo apk add ./proton-drive_*_alpine322_amd64.apk.tar.gz
           \`\`\`
 
           ## Checksums

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 1.4.2 - 2026-05-16
+
+### Added
+
+- Alpine 3.22 APK artifact in the release deployment so release tags now ship
+  both tested Alpine APK builds: 3.20 and 3.22.
+
+### Changed
+
+- Release workflow now waits for and packages the Alpine 3.22 APK build in
+  addition to Alpine 3.20.
+- Version metadata bumped to 1.4.2 for the packaging/deployment release.
+
+### Fixed
+
+- Release deployment previously omitted the Alpine 3.22 APK artifact even
+  though the build was green and the runtime smoke test had passed.
+
 ## 1.4.1 - 2026-05-16
 
 ### Added

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -90,7 +90,6 @@ described above. Both must pass for a target to be `release-gated`.
 | Package target | glibc gate | WebKitGTK gate | Workflow / artifact | Patch | Runtime smoke | Covered systems / rule | Next action |
 |----------------|-----------|----------------|---------------------|-------|---------------|------------------------|-------------|
 | openSUSE Leap 16 RPM | pass | pass | none yet / `rpm-package-opensuse-leap16` planned | `rpm/opensuse.leap.16.patch` | no release artifact | openSUSE Leap 16 | add zypper workflow, release artifact, and runtime smoke |
-| Alpine 3.22 APK | musl pass | pass | none yet / `apk-package-alpine322` planned | `apk/alpine.3.22.patch` | no release artifact | Alpine 3.22 musl; glibc artifacts are not compatible | add APK/musl workflow, release artifact, and runtime smoke |
 | Alpine 3.23 APK | musl pass | pass | none yet / `apk-package-alpine323` planned | `apk/alpine.3.23.patch` | no release artifact | Alpine 3.23 musl; glibc artifacts are not compatible | add APK/musl workflow, release artifact, and runtime smoke |
 
 ### Roadmap targets (no patch yet)
@@ -213,7 +212,7 @@ Runtime settings by baseline:
 | EL10 | same current-WebKitGTK path as Fedora |
 | openSUSE Tumbleweed | sandbox disable, `JSC_useWasmIPInt=false`, `GDK_GL=disable`, `LIBGL_ALWAYS_SOFTWARE=1`, `GSK_RENDERER=cairo` |
 | Alpine 3.20 APK | musl package target; `WEBKIT_DISABLE_DMABUF_RENDERER=1`, `WEBKIT_DISABLE_COMPOSITING_MODE=1`, `WEBKIT_DISABLE_SANDBOX_THIS_IS_DANGEROUS=1`, `JSC_useWasmIPInt=false`, `GDK_GL=disable`, `LIBGL_ALWAYS_SOFTWARE=1`, `GSK_RENDERER=cairo` |
-| Alpine 3.22/3.23 roadmap | musl package target plus current-WebKitGTK conservative path |
+| Alpine 3.23 roadmap | musl package target plus current-WebKitGTK conservative path |
 | Flatpak GNOME 49/50 | runtime-specific WebKitGTK settings for GNOME Platform targets |
 | Snap core24/core26 | wrapper/manifest WebKit paths plus package patch behavior |
 | AUR (native) | sandbox disable, `JSC_useWasmIPInt=false`; hardware rendering kept |
@@ -247,7 +246,7 @@ Release checklist:
   `packaging/compatibility-map.yml`.
 - `main` contains only the tested commits intended for release.
 - Release tag points at `main`.
-- GitHub release contains all 14 release-gated artifacts plus `SHA256SUMS`.
+- GitHub release contains all 16 release-gated artifacts plus `SHA256SUMS`.
 
 Promotion checklist for roadmap targets:
 

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -37,6 +37,7 @@ Use this checklist before every release deployment.
   - [ ] Snap workflows are passing.
 - [ ] AUR workflow is passing.
 - [ ] APK Alpine 3.20 workflow is passing.
+- [ ] APK Alpine 3.22 workflow is passing.
 - [ ] Release workflow is passing.
 
 - [ ] Merge approved PRs into `main`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "protondrive-linux",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "protondrive-linux",
-      "version": "1.4.1",
+      "version": "1.4.2",
       "license": "AGPL-3.0",
       "devDependencies": {
         "@tauri-apps/cli": "^2.11.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "protondrive-linux",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Proton Drive desktop client for Linux",
   "repository": {
     "type": "git",

--- a/scripts/ci/build-aur-package.sh
+++ b/scripts/ci/build-aur-package.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 AUR_TARGET="${1:-arch-native}"
-VERSION="${2:-1.4.1}"
+VERSION="${2:-1.4.2}"
 BINARY_PATH="${3:-src-tauri/target/release/proton-drive}"
 ICONS_DIR="${4:-src-tauri/icons}"
 REPO_ROOT="${5:-.}"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2858,7 +2858,7 @@ dependencies = [
 
 [[package]]
 name = "proton-drive"
-version = "1.4.1"
+version = "1.4.2"
 dependencies = [
  "base64 0.22.1",
  "dirs",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "proton-drive"
-version = "1.4.1"
+version = "1.4.2"
 description = "Proton Drive desktop client"
 authors = ["DonnieDice"]
 license = "AGPL-3.0"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Proton Drive",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "identifier": "com.proton.drive",
   "build": {
     "beforeBuildCommand": "",


### PR DESCRIPTION
Add Alpine 3.22 to the release deployment so the release tag ships both tested Alpine APK builds.

Scope:
- add Alpine 3.22 APK artifact download to `release.yml`
- add Alpine 3.22 to the release workflow wait list and artifact table
- bump package/version metadata to 1.4.2
- update changelog, release checklist, and packaging docs

Refs #62