### PR TITLE
(#69) Prevent stale RPM artifacts from reaching releases

### DIFF
--- a/.github/workflows/build-rpm.el10.yml
+++ b/.github/workflows/build-rpm.el10.yml
@@ -91,6 +91,7 @@ jobs:
       - name: Build RPM
         run: |
           . "$HOME/.cargo/env"
+          rm -rf src-tauri/target/release/bundle/rpm
           scripts/build-webclients.sh
           VERSION=$(node -p "require('./package.json').version")
           sed -i "s/\"version\": \"[^\"]*\"/\"version\": \"$VERSION\"/" src-tauri/tauri.conf.json

--- a/.github/workflows/build-rpm.fedora.43.yml
+++ b/.github/workflows/build-rpm.fedora.43.yml
@@ -87,6 +87,7 @@ jobs:
     - name: Build RPM
       run: |
         . "$HOME/.cargo/env"
+        rm -rf src-tauri/target/release/bundle/rpm
         scripts/build-webclients.sh
         VERSION=$(node -p "require('./package.json').version")
         sed -i "s/\"version\": \"[^\"]*\"/\"version\": \"$VERSION\"/" src-tauri/tauri.conf.json

--- a/.github/workflows/build-rpm.fedora.44.yml
+++ b/.github/workflows/build-rpm.fedora.44.yml
@@ -87,6 +87,7 @@ jobs:
     - name: Build RPM
       run: |
         . "$HOME/.cargo/env"
+        rm -rf src-tauri/target/release/bundle/rpm
         scripts/build-webclients.sh
         VERSION=$(node -p "require('./package.json').version")
         sed -i "s/\"version\": \"[^\"]*\"/\"version\": \"$VERSION\"/" src-tauri/tauri.conf.json

--- a/.github/workflows/build-rpm.opensuse.tumbleweed.yml
+++ b/.github/workflows/build-rpm.opensuse.tumbleweed.yml
@@ -95,6 +95,7 @@ jobs:
       - name: Build RPM
         run: |
           . "$HOME/.cargo/env"
+          rm -rf src-tauri/target/release/bundle/rpm
           scripts/build-webclients.sh
           VERSION=$(node -p "require('./package.json').version")
           sed -i "s/\"version\": \"[^\"]*\"/\"version\": \"$VERSION\"/" src-tauri/tauri.conf.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -274,10 +274,19 @@ jobs:
 
       - name: Prepare release files
         run: |
+          VERSION=$(node -p "require('./package.json').version")
           mkdir -p release
           find artifacts/ -type f \( -name "*.AppImage" -o -name "*.deb" -o -name "*.rpm" -o -name "*.flatpak" -o -name "*.snap" -o -name "*.pkg.tar.zst" -o -name "*.apk.tar.gz" \) -print0 | while IFS= read -r -d '' src; do
             rel="${src#artifacts/}"
             name="$(basename "$src")"
+            case "$name" in
+              *"${VERSION}"*)
+                ;;
+              *)
+                echo "Skipping stale artifact: $name"
+                continue
+                ;;
+            esac
             case "$rel" in
               rpm-fedora43/*)
                 dest="release/${name%.rpm}-fedora43.rpm"


### PR DESCRIPTION
Fixes stale Fedora 44 and EL10 RPM assets leaking into the GitHub Release by cleaning RPM bundle output before each RPM build and skipping version-mismatched artifacts during release assembly. Resolves #68.