### PR TITLE
(#70) Remove stale artifacts from all build workflows before packaging

### DIFF
--- a/.github/workflows/build-apk.alpine.3.20.yml
+++ b/.github/workflows/build-apk.alpine.3.20.yml
@@ -109,12 +109,13 @@ jobs:
           echo "WARNING: $PATCH_FILE not found, building without distro patch"
         fi
 
-    - name: Build APK
-      run: |
-        if [ -f "$HOME/.cargo/env" ]; then . "$HOME/.cargo/env"; fi
-        export PKG_CONFIG_ALLOW_CROSS=1
-        export PKG_CONFIG_PATH="/usr/lib/pkgconfig:/usr/share/pkgconfig"
-        scripts/build-webclients.sh
+- name: Build APK
+  run: |
+    if [ -f "$HOME/.cargo/env" ]; then . "$HOME/.cargo/env"; fi
+    export PKG_CONFIG_ALLOW_CROSS=1
+    export PKG_CONFIG_PATH="/usr/lib/pkgconfig:/usr/share/pkgconfig"
+    rm -rf /tmp/apk-artifact
+    scripts/build-webclients.sh
         VERSION=$(node -p "require('./package.json').version")
         sed -i "s/\"version\": \"[^\"]*\"/\"version\": \"$VERSION\"/" src-tauri/tauri.conf.json
         sed -i "0,/^version = \"[^\"]*\"/s//version = \"$VERSION\"/" src-tauri/Cargo.toml

--- a/.github/workflows/build-apk.alpine.3.22.yml
+++ b/.github/workflows/build-apk.alpine.3.22.yml
@@ -109,12 +109,13 @@ jobs:
           echo "WARNING: $PATCH_FILE not found, building without distro patch"
         fi
 
-    - name: Build APK
-      run: |
-        if [ -f "$HOME/.cargo/env" ]; then . "$HOME/.cargo/env"; fi
-        export PKG_CONFIG_ALLOW_CROSS=1
-        export PKG_CONFIG_PATH="/usr/lib/pkgconfig:/usr/share/pkgconfig"
-        scripts/build-webclients.sh
+- name: Build APK
+  run: |
+    if [ -f "$HOME/.cargo/env" ]; then . "$HOME/.cargo/env"; fi
+    export PKG_CONFIG_ALLOW_CROSS=1
+    export PKG_CONFIG_PATH="/usr/lib/pkgconfig:/usr/share/pkgconfig"
+    rm -rf /tmp/apk-artifact
+    scripts/build-webclients.sh
         VERSION=$(node -p "require('./package.json').version")
         sed -i "s/\"version\": \"[^\"]*\"/\"version\": \"$VERSION\"/" src-tauri/tauri.conf.json
         sed -i "0,/^version = \"[^\"]*\"/s//version = \"$VERSION\"/" src-tauri/Cargo.toml

--- a/.github/workflows/build-appimage.yml
+++ b/.github/workflows/build-appimage.yml
@@ -95,10 +95,11 @@ jobs:
        . "$HOME/.cargo/env"
        scripts/build-webclients.sh
 
-   - name: Build AppImage
-     run: |
-       . "$HOME/.cargo/env"
-       APPIMAGE_TARGET="${{ github.event.inputs.appimage_target || 'linux-baseline' }}"
+- name: Build AppImage
+  run: |
+    . "$HOME/.cargo/env"
+    rm -rf src-tauri/target/release/bundle/appimage
+    APPIMAGE_TARGET="${{ github.event.inputs.appimage_target || 'linux-baseline' }}"
        VERSION=$(node -p "require('./package.json').version")
        sed -i "s/\"version\": \"[^\"]*\"/\"version\": \"$VERSION\"/" src-tauri/tauri.conf.json
        sed -i "0,/^version = \"[^\"]*\"/s//version = \"$VERSION\"/" src-tauri/Cargo.toml

--- a/.github/workflows/build-aur.yml
+++ b/.github/workflows/build-aur.yml
@@ -72,8 +72,10 @@ jobs:
           exit 1
         fi
 
-    - name: Build WebClients
-      run: scripts/build-webclients.sh
+- name: Build WebClients
+  run: |
+    rm -rf /tmp/aur-output
+    scripts/build-webclients.sh
 
     - name: Build Tauri binary
       run: |

--- a/.github/workflows/build-deb.debian.13.yml
+++ b/.github/workflows/build-deb.debian.13.yml
@@ -90,10 +90,11 @@ jobs:
         echo "WARNING: $PATCH_FILE not found, building without distro patch"
       fi
 
-   - name: Build DEB
-     run: |
-      . "$HOME/.cargo/env"
-      scripts/build-webclients.sh
+- name: Build DEB
+  run: |
+    . "$HOME/.cargo/env"
+    rm -rf src-tauri/target/release/bundle/deb
+    scripts/build-webclients.sh
       VERSION=$(node -p "require('./package.json').version")
       sed -i "s/\"version\": \"[^\"]*\"/\"version\": \"$VERSION\"/" src-tauri/tauri.conf.json
       sed -i "0,/^version = \"[^\"]*\"/s//version = \"$VERSION\"/" src-tauri/Cargo.toml

--- a/.github/workflows/build-deb.ubuntu.24.04.yml
+++ b/.github/workflows/build-deb.ubuntu.24.04.yml
@@ -90,10 +90,11 @@ jobs:
             echo "WARNING: $PATCH_FILE not found, building without distro patch"
           fi
 
-      - name: Build DEB
-        run: |
-          . "$HOME/.cargo/env"
-          scripts/build-webclients.sh
+- name: Build DEB
+  run: |
+    . "$HOME/.cargo/env"
+    rm -rf src-tauri/target/release/bundle/deb
+    scripts/build-webclients.sh
           VERSION=$(node -p "require('./package.json').version")
           sed -i "s/\"version\": \"[^\"]*\"/\"version\": \"$VERSION\"/" src-tauri/tauri.conf.json
           sed -i "0,/^version = \"[^\"]*\"/s//version = \"$VERSION\"/" src-tauri/Cargo.toml

--- a/.github/workflows/build-deb.ubuntu.26.04.yml
+++ b/.github/workflows/build-deb.ubuntu.26.04.yml
@@ -90,10 +90,11 @@ jobs:
         echo "WARNING: $PATCH_FILE not found, building without distro patch"
       fi
 
-   - name: Build DEB
-     run: |
-      . "$HOME/.cargo/env"
-      scripts/build-webclients.sh
+- name: Build DEB
+  run: |
+    . "$HOME/.cargo/env"
+    rm -rf src-tauri/target/release/bundle/deb
+    scripts/build-webclients.sh
       VERSION=$(node -p "require('./package.json').version")
       sed -i "s/\"version\": \"[^\"]*\"/\"version\": \"$VERSION\"/" src-tauri/tauri.conf.json
       sed -i "0,/^version = \"[^\"]*\"/s//version = \"$VERSION\"/" src-tauri/Cargo.toml

--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -90,10 +90,11 @@ jobs:
           echo "WARNING: $PATCH_FILE not found, building without distro patch"
         fi
 
-    - name: Build DEB
-      run: |
-        . "$HOME/.cargo/env"
-        scripts/build-webclients.sh
+- name: Build DEB
+  run: |
+    . "$HOME/.cargo/env"
+    rm -rf src-tauri/target/release/bundle/deb
+    scripts/build-webclients.sh
         VERSION=$(node -p "require('./package.json').version")
         sed -i "s/\"version\": \"[^\"]*\"/\"version\": \"$VERSION\"/" src-tauri/tauri.conf.json
         sed -i "0,/^version = \"[^\"]*\"/s//version = \"$VERSION\"/" src-tauri/Cargo.toml

--- a/.github/workflows/build-flatpak.gnome49.yml
+++ b/.github/workflows/build-flatpak.gnome49.yml
@@ -88,10 +88,11 @@ jobs:
           echo "WARNING: $PATCH_FILE not found, building without distro patch"
         fi
 
-    - name: Build Flatpak
-      run: |
-        . "$HOME/.cargo/env"
-        scripts/build-webclients.sh
+- name: Build Flatpak
+  run: |
+    . "$HOME/.cargo/env"
+    rm -rf src-tauri/target/release/bundle/flatpak
+    scripts/build-webclients.sh
         VERSION=$(node -p "require('./package.json').version")
         sed -i "s/\"version\": \"[^\"]*\"/\"version\": \"$VERSION\"/" src-tauri/tauri.conf.json
         sed -i "0,/^version = \"[^\"]*\"/s//version = \"$VERSION\"/" src-tauri/Cargo.toml

--- a/.github/workflows/build-flatpak.yml
+++ b/.github/workflows/build-flatpak.yml
@@ -88,10 +88,11 @@ jobs:
           echo "WARNING: $PATCH_FILE not found, building without distro patch"
         fi
 
-    - name: Build Flatpak
-      run: |
-        . "$HOME/.cargo/env"
-        scripts/build-webclients.sh
+- name: Build Flatpak
+  run: |
+    . "$HOME/.cargo/env"
+    rm -rf src-tauri/target/release/bundle/flatpak
+    scripts/build-webclients.sh
         VERSION=$(node -p "require('./package.json').version")
         sed -i "s/\"version\": \"[^\"]*\"/\"version\": \"$VERSION\"/" src-tauri/tauri.conf.json
         sed -i "0,/^version = \"[^\"]*\"/s//version = \"$VERSION\"/" src-tauri/Cargo.toml

--- a/.github/workflows/build-snap.core26.yml
+++ b/.github/workflows/build-snap.core26.yml
@@ -90,10 +90,11 @@ jobs:
        echo "WARNING: $PATCH_FILE not found, building without distro patch"
       fi
 
-   - name: Build Snap
-     run: |
-      . "$HOME/.cargo/env"
-      scripts/build-webclients.sh
+- name: Build Snap
+  run: |
+    . "$HOME/.cargo/env"
+    rm -rf src-tauri/target/release/bundle/snap
+    scripts/build-webclients.sh
       VERSION=$(node -p "require('./package.json').version")
       sed -i "s/\"version\": \"[^\"]*\"/\"version\": \"$VERSION\"/" src-tauri/tauri.conf.json
       sed -i "0,/^version = \"[^\"]*\"/s//version = \"$VERSION\"/" src-tauri/Cargo.toml

--- a/.github/workflows/build-snap.yml
+++ b/.github/workflows/build-snap.yml
@@ -93,10 +93,11 @@ jobs:
           echo "WARNING: $PATCH_FILE not found, building without distro patch"
         fi
 
-    - name: Build Snap
-      run: |
-        . "$HOME/.cargo/env"
-        scripts/build-webclients.sh
+- name: Build Snap
+  run: |
+    . "$HOME/.cargo/env"
+    rm -rf src-tauri/target/release/bundle/snap
+    scripts/build-webclients.sh
         VERSION=$(node -p "require('./package.json').version")
         sed -i "s/\"version\": \"[^\"]*\"/\"version\": \"$VERSION\"/" src-tauri/tauri.conf.json
         sed -i "0,/^version = \"[^\"]*\"/s//version = \"$VERSION\"/" src-tauri/Cargo.toml


### PR DESCRIPTION
PR #69 only added stale-artifact guards to the 4 RPM workflows. This adds m -rf before the build step in the remaining 12 workflows so cached artifacts from a prior version can't leak into the current release output.

**Workflows fixed:**
- build-deb.yml (Debian 12)
- build-deb.ubuntu.24.04.yml
- build-deb.ubuntu.26.04.yml
- build-deb.debian.13.yml
- build-apk.alpine.3.20.yml
- build-apk.alpine.3.22.yml
- build-snap.yml
- build-snap.core26.yml
- build-flatpak.yml
- build-flatpak.gnome49.yml
- build-aur.yml
- build-appimage.yml

Closes #68