### PR TITLE
Fix CI workflow triggers for feature branches + add CONTRIBUTING.md

### DIFF
--- a/.github/workflows/build-apk.alpine.3.20.yml
+++ b/.github/workflows/build-apk.alpine.3.20.yml
@@ -3,10 +3,16 @@ name: Build APK Alpine 3.20
 "on":
   push:
     branches:
-    - main
-    - alpha
+      - main
+      - alpha
+      - "feature/**"
+      - "fix/**"
+      - "chore/**"
     tags:
-    - "v*"
+      - "v*"
+  pull_request:
+    branches:
+      - main
   workflow_dispatch:
     inputs:
       distro_patch:

--- a/.github/workflows/build-apk.alpine.3.22.yml
+++ b/.github/workflows/build-apk.alpine.3.22.yml
@@ -3,11 +3,16 @@ name: Build APK Alpine 3.22
 "on":
   push:
     branches:
-    - main
-    - dev
-    - alpha
+      - main
+      - alpha
+      - "feature/**"
+      - "fix/**"
+      - "chore/**"
     tags:
-    - "v*"
+      - "v*"
+  pull_request:
+    branches:
+      - main
   workflow_dispatch:
     inputs:
       distro_patch:

--- a/.github/workflows/build-appimage.yml
+++ b/.github/workflows/build-appimage.yml
@@ -5,8 +5,14 @@ name: Build AppImage
     branches:
       - main
       - alpha
+      - "feature/**"
+      - "fix/**"
+      - "chore/**"
     tags:
       - "v*"
+  pull_request:
+    branches:
+      - main
   workflow_dispatch:
     inputs:
       appimage_target:

--- a/.github/workflows/build-aur.yml
+++ b/.github/workflows/build-aur.yml
@@ -3,10 +3,16 @@ name: Build AUR Arch Native
 "on":
   push:
     branches:
-    - main
-    - alpha
+      - main
+      - alpha
+      - "feature/**"
+      - "fix/**"
+      - "chore/**"
     tags:
-    - "v*"
+      - "v*"
+  pull_request:
+    branches:
+      - main
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/build-deb.debian.13.yml
+++ b/.github/workflows/build-deb.debian.13.yml
@@ -5,8 +5,14 @@ name: Build DEB Debian 13
     branches:
       - main
       - alpha
+      - "feature/**"
+      - "fix/**"
+      - "chore/**"
     tags:
       - "v*"
+  pull_request:
+    branches:
+      - main
   workflow_dispatch:
     inputs:
       distro_patch:

--- a/.github/workflows/build-deb.ubuntu.24.04.yml
+++ b/.github/workflows/build-deb.ubuntu.24.04.yml
@@ -5,8 +5,14 @@ name: Build DEB Ubuntu 24.04
     branches:
       - main
       - alpha
+      - "feature/**"
+      - "fix/**"
+      - "chore/**"
     tags:
       - "v*"
+  pull_request:
+    branches:
+      - main
   workflow_dispatch:
     inputs:
       distro_patch:

--- a/.github/workflows/build-deb.ubuntu.26.04.yml
+++ b/.github/workflows/build-deb.ubuntu.26.04.yml
@@ -5,8 +5,14 @@ name: Build DEB Ubuntu 26.04
     branches:
       - main
       - alpha
+      - "feature/**"
+      - "fix/**"
+      - "chore/**"
     tags:
       - "v*"
+  pull_request:
+    branches:
+      - main
   workflow_dispatch:
     inputs:
       distro_patch:

--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -1,12 +1,18 @@
 name: Build DEB Debian 12
 
-on:
+"on":
   push:
     branches:
-    - main
-    - alpha
+      - main
+      - alpha
+      - "feature/**"
+      - "fix/**"
+      - "chore/**"
     tags:
-    - "v*"
+      - "v*"
+  pull_request:
+    branches:
+      - main
   workflow_dispatch:
     inputs:
       distro_patch:

--- a/.github/workflows/build-flatpak.gnome49.yml
+++ b/.github/workflows/build-flatpak.gnome49.yml
@@ -5,8 +5,14 @@ name: Build Flatpak GNOME 49
     branches:
       - main
       - alpha
+      - "feature/**"
+      - "fix/**"
+      - "chore/**"
     tags:
       - "v*"
+  pull_request:
+    branches:
+      - main
   workflow_dispatch:
     inputs:
       distro_patch:

--- a/.github/workflows/build-flatpak.yml
+++ b/.github/workflows/build-flatpak.yml
@@ -3,10 +3,16 @@ name: Build Flatpak
 "on":
   push:
     branches:
-    - main
-    - alpha
+      - main
+      - alpha
+      - "feature/**"
+      - "fix/**"
+      - "chore/**"
     tags:
-    - "v*"
+      - "v*"
+  pull_request:
+    branches:
+      - main
   workflow_dispatch:
     inputs:
       distro_patch:

--- a/.github/workflows/build-rpm.el10.yml
+++ b/.github/workflows/build-rpm.el10.yml
@@ -3,10 +3,16 @@ name: Build RPM EL10
 "on":
   push:
     branches:
-    - main
-    - alpha
+      - main
+      - alpha
+      - "feature/**"
+      - "fix/**"
+      - "chore/**"
     tags:
-    - "v*"
+      - "v*"
+  pull_request:
+    branches:
+      - main
   workflow_dispatch:
     inputs:
       distro_patch:

--- a/.github/workflows/build-rpm.fedora.43.yml
+++ b/.github/workflows/build-rpm.fedora.43.yml
@@ -1,12 +1,18 @@
 name: Build RPM Fedora 43
 
-on:
+"on":
   push:
     branches:
-    - main
-    - alpha
+      - main
+      - alpha
+      - "feature/**"
+      - "fix/**"
+      - "chore/**"
     tags:
-    - "v*"
+      - "v*"
+  pull_request:
+    branches:
+      - main
   workflow_dispatch:
     inputs:
       distro_patch:

--- a/.github/workflows/build-rpm.fedora.44.yml
+++ b/.github/workflows/build-rpm.fedora.44.yml
@@ -1,12 +1,18 @@
 name: Build RPM Fedora 44
 
-on:
+"on":
   push:
     branches:
-    - main
-    - alpha
+      - main
+      - alpha
+      - "feature/**"
+      - "fix/**"
+      - "chore/**"
     tags:
-    - "v*"
+      - "v*"
+  pull_request:
+    branches:
+      - main
   workflow_dispatch:
     inputs:
       distro_patch:

--- a/.github/workflows/build-rpm.opensuse.tumbleweed.yml
+++ b/.github/workflows/build-rpm.opensuse.tumbleweed.yml
@@ -5,8 +5,14 @@ name: Build RPM openSUSE Tumbleweed
     branches:
       - main
       - alpha
+      - "feature/**"
+      - "fix/**"
+      - "chore/**"
     tags:
       - "v*"
+  pull_request:
+    branches:
+      - main
   workflow_dispatch:
     inputs:
       distro_patch:

--- a/.github/workflows/build-snap.core26.yml
+++ b/.github/workflows/build-snap.core26.yml
@@ -5,8 +5,14 @@ name: Build Snap Core26
     branches:
       - main
       - alpha
+      - "feature/**"
+      - "fix/**"
+      - "chore/**"
     tags:
       - "v*"
+  pull_request:
+    branches:
+      - main
   workflow_dispatch:
     inputs:
       distro_patch:

--- a/.github/workflows/build-snap.yml
+++ b/.github/workflows/build-snap.yml
@@ -3,10 +3,16 @@ name: Build Snap
 "on":
   push:
     branches:
-    - main
-    - alpha
+      - main
+      - alpha
+      - "feature/**"
+      - "fix/**"
+      - "chore/**"
     tags:
-    - "v*"
+      - "v*"
+  pull_request:
+    branches:
+      - main
   workflow_dispatch:
     inputs:
       distro_patch:

--- a/.github/workflows/generate-package-specs.yml
+++ b/.github/workflows/generate-package-specs.yml
@@ -1,12 +1,18 @@
 name: Generate Package Specs
 
-on:
+"on":
   push:
     branches:
       - main
       - alpha
+      - "feature/**"
+      - "fix/**"
+      - "chore/**"
     tags:
       - "v*"
+  pull_request:
+    branches:
+      - main
   workflow_dispatch:
 
 permissions:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,77 @@
+# Contributing to Proton Drive Linux
+
+Thanks for your interest in contributing! This guide covers the workflow we use for issues, branches, and pull requests.
+
+## Workflow
+
+Every meaningful change follows this loop:
+
+```
+Open Issue → Create Branch → Push Commits → Open PR → CI Runs → Review → Merge → Issue Auto-Closes
+```
+
+## Issues
+
+Open an issue for every bug, feature request, or task. Issues:
+
+- Track what's open/done
+- Link commits and PRs back to intent (`Closes #42` auto-closes the issue on merge)
+- Discuss the *why* before touching code
+
+## Branch Naming Convention
+
+One branch per issue, named to make the connection explicit:
+
+| Prefix    | Use case                         | Example                        |
+|-----------|----------------------------------|--------------------------------|
+| `feature/` | New functionality               | `feature/42-add-login-page`    |
+| `fix/`     | Bug fixes                       | `fix/87-broken-csv-export`     |
+| `chore/`   | Non-code work (docs, deps, CI)  | `chore/103-update-dependencies`|
+
+**Never work directly on `main`.** Even for a one-line fix, create a branch and open a PR.
+
+## Pull Requests
+
+Open a PR when your branch is ready for review. A PR:
+
+- Triggers CI (all build workflows run automatically)
+- Lets reviewers check the diff
+- Creates a record of *why* code changed (link it back to the issue with `Closes #N`)
+
+## Testing Builds on Feature Branches
+
+All build workflows trigger on pushes to `feature/**`, `fix/**`, and `chore/**` branches. To test a build:
+
+1. Push your branch
+2. Go to the **Actions** tab on GitHub
+3. Find the workflow run for your push
+4. Download the build artifact from the run summary
+
+Artifacts are retained for 30 days and include the branch name for easy identification.
+
+## CI Workflows
+
+| Workflow | Triggers on |
+|----------|-------------|
+| Build workflows (AppImage, Flatpak, Snap, DEB, RPM, APK, AUR) | Push to `main`, `alpha`, `feature/**`, `fix/**`, `chore/**` + tags + PRs to `main` |
+| Generate Package Specs | Same as build workflows |
+| Release | Push to `main` + tags only |
+| Publish AUR | Release events only |
+
+## Branch Protection
+
+`main` is the production-ready branch with protection rules:
+
+- Require PR before merging
+- Require status checks to pass
+- Require branches to be up to date before merging
+
+## Quick Decision Guide
+
+| Situation              | What to create                                      |
+|------------------------|-----------------------------------------------------|
+| Bug found              | Issue + `fix/N-description` branch + PR             |
+| New feature            | Issue + `feature/N-description` branch + PR         |
+| Tiny typo fix          | Branch + PR (skip the issue if truly trivial)       |
+| Want to test a build   | Push to feature branch → Actions tab → download artifact |
+| Ready to ship          | PR → CI passes → review → merge to main             |


### PR DESCRIPTION
﻿## Changes

- Add `feature/**`, `fix/**`, `chore/**` to push triggers on all 17 build/spec workflows
- Add `pull_request` trigger targeting `main` on all build workflows
- Normalize unquoted `on:` to quoted `"on":` for YAML consistency (build-deb.yml, build-rpm.fedora.43/44, generate-package-specs.yml)
- Remove orphaned `dev` branch from alpine 3.22 (replaced by `feature/**` glob pattern)
- Add CONTRIBUTING.md with branch naming conventions, issue/PR workflow, and CI docs

## What this fixes

Previously, CI only ran on pushes to `main` and `alpha`. Pushing to `feature/*`, `fix/*`, or `chore/*` branches produced no build artifacts and no CI feedback. Now all build workflows trigger on feature branches, so you can push and immediately download artifacts from the Actions tab.

## Workflows updated (17)

- build-appimage.yml
- build-flatpak.yml
- build-flatpak.gnome49.yml
- build-snap.yml
- build-snap.core26.yml
- build-aur.yml
- build-deb.yml
- build-deb.debian.13.yml
- build-deb.ubuntu.24.04.yml
- build-deb.ubuntu.26.04.yml
- build-rpm.el10.yml
- build-rpm.fedora.43.yml
- build-rpm.fedora.44.yml
- build-rpm.opensuse.tumbleweed.yml
- build-apk.alpine.3.20.yml
- build-apk.alpine.3.22.yml
- generate-package-specs.yml

## Workflows left as-is (2)

- release.yml (should only trigger on main/tags)
- publish-aur.yml (should only trigger on releases)

Closes #71
