### PR TITLE
(#76) User-facing README overhaul, distribution storefront roadmap, and doc consistency fixes

### DIFF
--- a/.github/workflows/build-rpm.opensuse.tumbleweed.yml
+++ b/.github/workflows/build-rpm.opensuse.tumbleweed.yml
@@ -43,18 +43,33 @@ jobs:
         shell: /bin/bash -e -o pipefail {0}
 
     steps:
-      - name: Install build dependencies
-        shell: /bin/sh -e {0}
-        run: |
-          zypper --non-interactive refresh
-          zypper --non-interactive install \
-            bash git curl wget gcc gcc-c++ make file pkgconf-pkg-config \
-            libopenssl-devel gtk3-devel \
-            libappindicator3-devel libayatana-appindicator3-devel \
-            librsvg-devel libsoup-devel \
-            webkitgtk3-devel libwebkit2gtk-4_1-0 \
-            patchelf rpm-build nodejs-default npm-default python313 findutils which
-          echo "/usr/local/bin:/usr/bin:/bin" >> "$GITHUB_PATH"
+  - name: Install build dependencies
+    shell: /bin/sh -e {0}
+    run: |
+      retry_cmd() {
+        max=${1:-3}; shift
+        attempt=1
+        until "$@"; do
+          if [ $attempt -ge $max ]; then
+            echo "Command failed after $attempt attempts: $*" >&2
+            return 1
+          fi
+          echo "Command failed, retrying ($attempt/$max): $*"
+          sleep $((attempt * 10))
+          attempt=$((attempt + 1))
+        done
+        return 0
+      }
+
+      retry_cmd 5 zypper --non-interactive --gpg-auto-import-keys refresh
+      retry_cmd 3 zypper --non-interactive install \
+        bash git curl wget gcc gcc-c++ make file pkgconf-pkg-config \
+        libopenssl-devel gtk3-devel \
+        libappindicator3-devel libayatana-appindicator3-devel \
+        librsvg-devel libsoup-devel \
+        webkitgtk3-devel libwebkit2gtk-4_1-0 \
+        patchelf rpm-build nodejs-default npm-default python313 findutils which
+      echo "/usr/local/bin:/usr/bin:/bin" >> "$GITHUB_PATH"
 
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/build-rpm.opensuse.tumbleweed.yml
+++ b/.github/workflows/build-rpm.opensuse.tumbleweed.yml
@@ -46,29 +46,24 @@ jobs:
   - name: Install build dependencies
     shell: /bin/sh -e {0}
     run: |
-      retry_cmd() {
-        max=${1:-3}; shift
-        attempt=1
-        until "$@"; do
-          if [ $attempt -ge $max ]; then
-            echo "Command failed after $attempt attempts: $*" >&2
-            return 1
-          fi
-          echo "Command failed, retrying ($attempt/$max): $*"
-          sleep $((attempt * 10))
-          attempt=$((attempt + 1))
-        done
-        return 0
-      }
+      for i in 1 2 3 4 5; do
+        zypper --non-interactive --gpg-auto-import-keys refresh && break
+        echo "zypper refresh failed, retrying ($i/5)..."
+        sleep $((i * 10))
+      done
 
-      retry_cmd 5 zypper --non-interactive --gpg-auto-import-keys refresh
-      retry_cmd 3 zypper --non-interactive install \
-        bash git curl wget gcc gcc-c++ make file pkgconf-pkg-config \
-        libopenssl-devel gtk3-devel \
-        libappindicator3-devel libayatana-appindicator3-devel \
-        librsvg-devel libsoup-devel \
-        webkitgtk3-devel libwebkit2gtk-4_1-0 \
-        patchelf rpm-build nodejs-default npm-default python313 findutils which
+      for i in 1 2 3; do
+        zypper --non-interactive install \
+          bash git curl wget gcc gcc-c++ make file pkgconf-pkg-config \
+          libopenssl-devel gtk3-devel \
+          libappindicator3-devel libayatana-appindicator3-devel \
+          librsvg-devel libsoup-devel \
+          webkitgtk3-devel libwebkit2gtk-4_1-0 \
+          patchelf rpm-build nodejs-default npm-default python313 findutils which && break
+        echo "zypper install failed, retrying ($i/3)..."
+        sleep $((i * 10))
+      done
+
       echo "/usr/local/bin:/usr/bin:/bin" >> "$GITHUB_PATH"
 
       - name: Checkout repository

--- a/.github/workflows/build-rpm.opensuse.tumbleweed.yml
+++ b/.github/workflows/build-rpm.opensuse.tumbleweed.yml
@@ -46,12 +46,15 @@ jobs:
   - name: Install build dependencies
     shell: /bin/sh -e {0}
     run: |
+      refresh_ok=0
       for i in 1 2 3 4 5; do
-        zypper --non-interactive --gpg-auto-import-keys refresh && break
+        zypper --non-interactive --gpg-auto-import-keys refresh && refresh_ok=1 && break
         echo "zypper refresh failed, retrying ($i/5)..."
         sleep $((i * 10))
       done
+      [ "$refresh_ok" -eq 1 ] || { echo "zypper refresh failed after 5 attempts"; exit 1; }
 
+      install_ok=0
       for i in 1 2 3; do
         zypper --non-interactive install \
           bash git curl wget gcc gcc-c++ make file pkgconf-pkg-config \
@@ -59,10 +62,11 @@ jobs:
           libappindicator3-devel libayatana-appindicator3-devel \
           librsvg-devel libsoup-devel \
           webkitgtk3-devel libwebkit2gtk-4_1-0 \
-          patchelf rpm-build nodejs-default npm-default python313 findutils which && break
+          patchelf rpm-build nodejs-default npm-default python313 findutils which && install_ok=1 && break
         echo "zypper install failed, retrying ($i/3)..."
         sleep $((i * 10))
       done
+      [ "$install_ok" -eq 1 ] || { echo "zypper install failed after 3 attempts"; exit 1; }
 
       echo "/usr/local/bin:/usr/bin:/bin" >> "$GITHUB_PATH"
 

--- a/.opencode/agent/protondrive-conventions.md
+++ b/.opencode/agent/protondrive-conventions.md
@@ -55,7 +55,7 @@ gh api repos/DonnieDice/protondrive-linux/pulls/NUMBER/files \
 Do **not** fabricate or guess the diff hashes — always fetch them from the
 API. Each link follows the pattern:
 
-```
+```text
 https://github.com/DonnieDice/protondrive-linux/pull/NUMBER/files#diff-{SHA}
 ```
 

--- a/.opencode/agent/protondrive-conventions.md
+++ b/.opencode/agent/protondrive-conventions.md
@@ -30,22 +30,34 @@ mode: primary
 ## PR Body Format
 
 Reference the issue at the top, then list each changed file with a GitHub
-permalink so reviewers can jump directly to the source:
+diff anchor so reviewers can jump directly to that file's diff in the PR:
 
 ```markdown
 Issue: #42
 
 ## Changes
 
-### [`README.md`](https://github.com/DonnieDice/protondrive-linux/blob/<branch>/README.md) — description of changes
+### [`README.md`](https://github.com/DonnieDice/protondrive-linux/pull/47/files#diff-abc123) — description of changes
 - Bullet list of what changed in this file
 
-### [`docs/packaging.md`](https://github.com/DonnieDice/protondrive-linux/blob/<branch>/docs/packaging.md) — description of changes
+### [`docs/packaging.md`](https://github.com/DonnieDice/protondrive-linux/pull/47/files#diff-def456) — description of changes
 - Bullet list of what changed in this file
 ```
 
-Replace `<branch>` with the feature branch name. Each changed file gets its own
-`###` heading with a GitHub blob link and a brief summary.
+The `#diff-` anchor is the file's SHA from the PR files API. To get the
+real SHAs before editing the PR body:
+
+```bash
+gh api repos/DonnieDice/protondrive-linux/pulls/NUMBER/files \
+  --jq '.[] | .filename + " " + .sha'
+```
+
+Do **not** fabricate or guess the diff hashes — always fetch them from the
+API. Each link follows the pattern:
+
+```
+https://github.com/DonnieDice/protondrive-linux/pull/NUMBER/files#diff-{SHA}
+```
 
 ## Branch Naming
 

--- a/.opencode/agent/protondrive-conventions.md
+++ b/.opencode/agent/protondrive-conventions.md
@@ -1,0 +1,87 @@
+---
+description: Project conventions for protondrive-linux — commit messages, PR titles, PR body format, branching, and version bumps. Load before every task.
+mode: primary
+---
+
+# ProtonDrive Linux Project Conventions
+
+## Repository
+
+- Repo: `donniedice/protondrive-linux`
+- Default branch: `main`
+- **Never push directly to `main`** — always use Issue → Branch → PR → Merge
+
+## Commit Messages
+
+- Format: `(#N) Description` where N is the **issue** number
+- Start with uppercase letter
+- At least 10 characters after the issue prefix
+- Regex: `^\(#\d+\)\s[A-Z].{9,}$`
+- Use `Closes #N` or `Refs #N` in commit body/footer for traceability
+- The number in the commit title is the **issue** number, not the PR number
+
+## PR Titles
+
+- Format: `(#PR-number) Descriptive title starting with uppercase`
+- The number in the PR title is the **PR** number (assigned by GitHub after creation)
+- Edit the title after GitHub assigns the PR number
+- Same regex as commits: `^\(#\d+\)\s[A-Z].{9,}$`
+
+## PR Body Format
+
+Reference the issue at the top, then list each changed file with a GitHub
+permalink so reviewers can jump directly to the source:
+
+```markdown
+Issue: #42
+
+## Changes
+
+### [`README.md`](https://github.com/DonnieDice/protondrive-linux/blob/<branch>/README.md) — description of changes
+- Bullet list of what changed in this file
+
+### [`docs/packaging.md`](https://github.com/DonnieDice/protondrive-linux/blob/<branch>/docs/packaging.md) — description of changes
+- Bullet list of what changed in this file
+```
+
+Replace `<branch>` with the feature branch name. Each changed file gets its own
+`###` heading with a GitHub blob link and a brief summary.
+
+## Branch Naming
+
+| Prefix | Use case | Example |
+|--------|----------|---------|
+| `feature/` | New functionality | `feature/42-add-login-page` |
+| `fix/` | Bug fixes | `fix/87-broken-csv-export` |
+| `chore/` | Non-code work (docs, deps, CI) | `chore/103-update-dependencies` |
+
+Always clean up remote branches after merge.
+
+## Version Bumps
+
+When merging meaningful changes, bump the version in ALL THREE files:
+- `package.json`
+- `src-tauri/tauri.conf.json`
+- `src-tauri/Cargo.toml`
+
+## CI Workflows
+
+- 17 build/spec workflows trigger on `push` to `main`, `alpha`, `feature/**`, `fix/**`, `chore/**` + tags + PRs to `main`
+- `release.yml` and `publish-aur.yml` are main/tags-only — do NOT add feature branch triggers
+- CommitCheck false positives can be ignored when the message follows `(#N) Description` correctly
+
+## Packaging State
+
+- Alpine 3.23 has a workflow (`build-apk.alpine.3.23.yml`) but is still `roadmap-patch-ready` — not release-gated yet
+- `compatibility-map.yml` must stay in sync with actual workflows and `docs/packaging.md`
+- AUR package is `proton-drive` (native build), not `proton-drive-bin` (old wrapper, replaced in v1.4.0)
+
+## Key Docs
+
+- `CONTRIBUTING.md` — root workflow guide (branches, commits, PRs)
+- `docs/CONTRIBUTING.md` — detailed build, packaging, development rules
+- `docs/packaging.md` — canonical human-readable packaging policy
+- `packaging/compatibility-map.yml` — machine-readable target metadata
+- `docs/CHANGELOG.md` — release history
+- `docs/release-checklist.md` — pre-release checklist
+- `docs/new-build-checklist.md` — adding new package targets

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,6 +64,27 @@ number — it appears in the URL and page header immediately. A PR:
 - Lets reviewers check the diff
 - Creates a record of *why* code changed
 
+### PR Body Format
+
+Reference the issue at the top, then list each changed file with a GitHub
+permalink so reviewers can jump directly to the source. Each changed file gets
+its own line with a link and a brief summary:
+
+```markdown
+Issue: #42
+
+## Changes
+
+### [`README.md`](https://github.com/DonnieDice/protondrive-linux/blob/<branch>/README.md) — description of changes
+- Bullet list of what changed in this file
+
+### [`docs/packaging.md`](https://github.com/DonnieDice/protondrive-linux/blob/<branch>/docs/packaging.md) — description of changes
+- Bullet list of what changed in this file
+```
+
+Replace `<branch>` with your feature branch name. After the PR is merged the
+links will resolve to `main`, but during review they point to the exact branch.
+
 ## Testing Builds on Feature Branches
 
 All build workflows trigger on pushes to `feature/**`, `fix/**`, and `chore/**` branches. To test a build:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,8 @@ git commit -m "(#123) Add system tray icon support"
 ```
 
 Rules:
+- The number in the commit title is the **issue** number (e.g., `#123`), not
+  the PR number
 - Start with an uppercase letter
 - Be at least 10 characters long (after the issue number prefix)
 - Put the issue number prefix at the start: `(#42) Title here`
@@ -54,7 +56,9 @@ Open a PR when your branch is ready for review. PR title format:
 
 The PR title must match: `^\(#\d+\)\s[A-Z].{9,}$`
 
-Edit the PR title after GitHub assigns the PR number. A PR:
+The number in the PR title is the **PR** number (assigned by GitHub after you
+open the PR), not the issue number. Edit the title after GitHub assigns the PR
+number — it appears in the URL and page header immediately. A PR:
 
 - Triggers CI (all build workflows run automatically)
 - Lets reviewers check the diff

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,7 +92,7 @@ gh api repos/DonnieDice/protondrive-linux/pulls/NUMBER/files \
 Do **not** fabricate or guess the diff hashes — always fetch them from the
 API. Each link follows the pattern:
 
-```
+```text
 https://github.com/DonnieDice/protondrive-linux/pull/NUMBER/files#diff-{SHA}
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,23 +67,34 @@ number — it appears in the URL and page header immediately. A PR:
 ### PR Body Format
 
 Reference the issue at the top, then list each changed file with a GitHub
-permalink so reviewers can jump directly to the source. Each changed file gets
-its own line with a link and a brief summary:
+diff anchor so reviewers can jump directly to that file's diff in the PR:
 
 ```markdown
 Issue: #42
 
 ## Changes
 
-### [`README.md`](https://github.com/DonnieDice/protondrive-linux/blob/<branch>/README.md) — description of changes
+### [`README.md`](https://github.com/DonnieDice/protondrive-linux/pull/47/files#diff-abc123) — description of changes
 - Bullet list of what changed in this file
 
-### [`docs/packaging.md`](https://github.com/DonnieDice/protondrive-linux/blob/<branch>/docs/packaging.md) — description of changes
+### [`docs/packaging.md`](https://github.com/DonnieDice/protondrive-linux/pull/47/files#diff-def456) — description of changes
 - Bullet list of what changed in this file
 ```
 
-Replace `<branch>` with your feature branch name. After the PR is merged the
-links will resolve to `main`, but during review they point to the exact branch.
+The `#diff-` anchor is the file's SHA from the PR files API. To get the
+real SHAs before editing the PR body:
+
+```bash
+gh api repos/DonnieDice/protondrive-linux/pulls/NUMBER/files \
+  --jq '.[] | .filename + " " + .sha'
+```
+
+Do **not** fabricate or guess the diff hashes — always fetch them from the
+API. Each link follows the pattern:
+
+```
+https://github.com/DonnieDice/protondrive-linux/pull/NUMBER/files#diff-{SHA}
+```
 
 ## Testing Builds on Feature Branches
 

--- a/LICENSE
+++ b/LICENSE
@@ -18,7 +18,7 @@ share and change all versions of a program--to make sure it remains free
 software for all its users.
 
   When we speak of free software, we are referring to freedom, not
-price.  Our General Public Licases are designed to make sure that you
+price.  Our General Public Licenses are designed to make sure that you
 have the freedom to distribute copies of free software (and charge for
 them if you wish), that you receive source code or can get it if you
 want it, that you can change the software or use pieces of it in new

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,660 @@
+GNU AFFERO GENERAL PUBLIC LICENSE
+Version 3, 19 November 2007
+
+Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+
+Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU Affero General Public License is a free, copyleft license for
+software and other kinds of works, specifically designed to ensure
+cooperation with the community in the case of network server software.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+our General Public Licenses are intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licases are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  Developers that use our General Public Licenses protect your rights
+with two steps: (1) assert copyright on the software, and (2) offer
+you this License which gives you legal permission to copy, distribute
+and/or modify the software.
+
+  A secondary benefit of defending all users' freedom is that
+improvements made in alternate versions of the program, if they
+receive widespread use, become available for other developers to
+incorporate.  Many developers of free software are heartened and
+encouraged by the resulting cooperation.
+
+  However, in the case of software used on network servers, this
+result may fail to come about.  The GNU General Public License permits
+making a modified version and letting the public access it on a
+server without ever releasing its source code to the public.
+
+  The GNU Affero General Public License is designed specifically to
+ensure that, in such cases, the modified source code becomes available
+to the community.  It requires the operator of a network server to
+provide the source code of the modified version running there to the
+users of that server.  Therefore, public use of a modified version, on
+a publicly accessible server, gives the public access to the source
+code of the modified version.
+
+  An older license, called the Affero General Public License and
+published by Affero, was designed to accomplish similar goals.  This is
+a different license, not a version of the Affero GPL, but Affero has
+published a new version of the Affero GPL which permits relicensing
+under this license.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU Affero General Public
+License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds
+of works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not convey,
+without conditions so long as your license otherwise remains in force.
+
+  You may convey covered works to others for the sole purpose of having
+them make modifications exclusively for you, or provide you with
+facilities for running those works, provided that you comply with the
+terms of this License in conveying all material for which you do not
+control copyright.  Those thus making or running the covered works for
+you must do so exclusively on your behalf, under your direction and
+control, on terms that prohibit them from making any copies of your
+copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to the
+covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any non-permissive
+terms added in accord with section 7 apply to the code; keep intact all
+notices of the absence of any warranty; and give all recipients a copy
+of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms of
+sections 4 and 5, provided that you also convey the machine-readable
+Corresponding Source under the terms of this License, in one of these
+ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the Corresponding
+    Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.
+
+    e) Convey the object code using peer-to-peer transmission,
+    provided you inform other peers where the object code and
+    Corresponding Source of the work are being offered to the general
+    public at no charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for
+incorporation into a dwelling.  In determining whether a product is a
+consumer product, doubtful cases shall be resolved in favor of coverage.
+For a particular product received by a particular user, "normally used"
+refers to a typical or common use of that class of product, regardless
+of the status of the particular user or of the way in which the
+particular user actually uses, or expects or is expected to use, the
+product.  A product is a consumer product regardless of whether it has
+substantial commercial, industrial or non-consumer uses, unless such
+uses represent the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product
+from a modified version of its Corresponding Source.  The information
+must suffice to ensure that the continued functioning of the modified
+object code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied by
+the Installation Information.  But this requirement does not apply if
+neither you nor any third party retains the ability to install modified
+object code on the User Product (for example, the work has been
+installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.
+
+  Access to a network may be denied when the modification itself
+materially and adversely affects the operation of the network or
+violates the rules and protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in source
+code form), and must require no special password or key for unpacking,
+reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)
+
+  You may place additional permissions on material, added by you to a
+covered work, for which you have or can give appropriate copyright
+permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders
+of that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors or authors of that
+    material by anyone who conveys the material (or modified versions
+    of it) with contractual assumptions of liability to the recipient,
+    for any liability that these contractual assumptions directly
+    impose on those licensors or authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+receive it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further restriction,
+you may remove that term.  If a license document contains a further
+restriction but permits relicensing or conveying under this License, you
+may add to a covered work material governed by the terms of that license
+document, provided that the further restriction does not survive such
+relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the additional
+terms that apply to those files, or a notice indicating where to find
+the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions; the above
+requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your license
+from a particular copyright holder is reinstated (a) provisionally,
+unless and until the copyright holder explicitly and finally terminates
+your license, and (b) permanently, if the copyright holder fails to
+notify you of the violation by some reasonable means prior to 60 days
+after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after your
+receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.
+
+  If your rights have been terminated and not permanently reinstated,
+you do not qualify to receive new licenses for the same material under
+section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or run
+a copy of the Program.  Ancillary propagation of a covered work occurring
+solely as a consequence of using peer-to-peer transmission to receive a
+copy likewise does not require acceptance.
+
+  However, nothing other than this License grants you permission to
+propagate or modify any covered work.  These actions infringe copyright
+if you do not accept this License.  Therefore, by modifying or
+propagating a covered work, you indicate your acceptance of this License
+to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered work
+results from an entity transaction, each party to that transaction who
+receives a copy of the work also receives whatever licenses to the work
+the party's predecessor in interest had or could give under the previous
+paragraph, plus a right to possession of the Corresponding Source of the
+work from the predecessor in interest, if the predecessor has it or can
+get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may not
+impose a license fee, royalty, or other charge for exercise of rights
+granted under this License, and you may not initiate litigation (including
+a cross-claim or counterclaim in a lawsuit) alleging that any patent
+claim is infringed by making, using, selling, offering for sale, or
+importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The work
+thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims owned
+or controlled by the contributor, whether already acquired or hereafter
+acquired, that would be infringed by some manner, permitted by this
+License, of making, using, or selling its contributor version, but do not
+include claims that would be infringed only as a consequence of further
+modification of the contributor version.
+
+  For purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of this
+License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to make,
+use, sell, offer for sale, import and otherwise run, modify and propagate
+the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone to
+copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties receiving
+the covered work authorizing them to use, propagate, modify or convey a
+specific copy of the covered work, then the patent license you grant is
+automatically extended to all recipients of the covered work and works
+based on it.
+
+  A patent license is "discriminatory" if it does not include within the
+scope of its coverage, prohibits the exercise of, or is conditioned on the
+non-exercise of one or more of the rights that are specifically granted
+under this License.  You may not convey a covered work if you are a party
+to an arrangement with a third party that is in the business of
+distributing software, under which you make payment to the third party
+based on the extent of your activity of conveying the work, and under
+which the third party grants, to any of the parties who would receive the
+covered work from you, a discriminatory patent license (a) in connection
+with copies of the covered work conveyed by you (or copies made from
+those copies), or (b) primarily for and in connection with specific
+products or compilations that contain the covered work, unless you entered
+into that arrangement, or that patent license was granted, prior to 28
+March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting any
+implied license or other defenses to infringement that may otherwise be
+available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not convey it at all.
+
+  13. Remote Network Interaction; Use with the GNU General Public License.
+
+  Notwithstanding any other provision of this License, if you modify the
+Program, your modified version must prominently offer all users
+interacting with it remotely through a computer network (if your version
+supports such interaction) an opportunity to receive the Corresponding
+Source of your version by providing access to the Corresponding Source
+from a network server at no charge, through some standard or customary
+means of facilitating copying of software.  This Corresponding Source
+shall include the Corresponding Source for any work covered by version 3
+of the GNU General Public License that is incorporated pursuant to the
+following paragraph.
+
+  Notwithstanding any other provision of this License, you have permission
+to link or combine any covered work with a work licensed under version 3
+of the GNU General Public License into a single combined work, and to
+convey the resulting work.  The terms of this License will continue to
+apply to the part which is the covered work, but the work with which it
+is combined will remain governed by version 3 of the GNU General Public
+License.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU Affero General Public License from time to time.  Such new
+versions will be similar in spirit to the present version, but may differ
+in detail to address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the Program
+specifies that a certain numbered version of the GNU Affero General
+Public License "or any later version" applies to it, you have the option
+of following the terms and conditions either of that numbered version or
+of any later version published by the Free Software Foundation.  If the
+Program does not specify a version number of the GNU Affero General
+Public License, you may choose any version ever published by the Free
+Software Foundation.
+
+  If the Program specifies that a proxy can decide which future versions
+of the GNU Affero General Public License can be used, that proxy's public
+statement of acceptance of a version permanently authorizes you to choose
+that version for the Program.
+
+  Later license versions may give you additional or different permissions.
+However, no additional obligations are imposed on any author or copyright
+holder as a result of your choosing to follow a later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE
+PROGRAM IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE
+COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING
+ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF
+THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS
+OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR
+THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates an
+absolute waiver of all civil liability in connection with the Program,
+unless a warranty or assumption of liability accompanies a copy of the
+Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these
+terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least the
+"copyright" line and a pointer to where the full notice is found.
+
+    ProtonDrive Linux
+    Copyright (C) 2024-2026 Joseph Gettings Jr.
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published
+    by the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If your software can interact with users remotely through a computer
+network, you should also make sure that it provides a way for users to
+get its source.  For example, if your program is a web application, its
+interface could display a "Source" link that leads users to an archive of
+the code.  There are many ways you could offer source, and different
+solutions will be better for different programs; see section 13 for the
+specific requirements.
+
+  You should also get your employer (if you work as a programmer) or
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  For more information on this, and how to apply and follow the
+GNU AGPL, see <https://www.gnu.org/licenses/>.

--- a/README.md
+++ b/README.md
@@ -1,64 +1,73 @@
 # ProtonDrive Linux
 
-An unofficial desktop app for Proton Drive on Linux.
+[![Latest Release](https://img.shields.io/github/v/release/DonnieDice/protondrive-linux?label=latest&color=brightgreen)](https://github.com/DonnieDice/protondrive-linux/releases/latest)
+[![CI](https://img.shields.io/github/actions/workflow/status/DonnieDice/protondrive-linux/release.yml?branch=main&label=release%20CI)](https://github.com/DonnieDice/protondrive-linux/actions/workflows/release.yml)
+[![License](https://img.shields.io/badge/license-AGPL--3.0-blue)](https://github.com/DonnieDice/protondrive-linux)
+[![AUR](https://img.shields.io/aur/version/proton-drive?label=AUR&color=blue)](https://aur.archlinux.org/packages/proton-drive)
 
-> This project is not affiliated with Proton AG.
+An unofficial desktop client for [Proton Drive](https://proton.me/drive) on Linux.
 
-## Download
+> **Disclaimer:** This project is not affiliated with, endorsed by, or connected to Proton AG. Proton Drive is a trademark of Proton AG. This is an independent community project that wraps the official Proton Drive web interface in a native Linux desktop window.
 
-Download the latest release from the
-[Releases](https://github.com/DonnieDice/protondrive-linux/releases) page.
+---
 
-Packages are distributed as GitHub release artifacts. There is no apt
-repository, Flathub listing, or Snap Store listing at this time.
+**Packages are not yet available on Flathub, Snap Store, or system repositories.** See the [Distribution Storefront Roadmap](#distribution-storefront-roadmap) for progress. For now, download from [Releases](https://github.com/DonnieDice/protondrive-linux/releases/latest).
 
-## Current Release Support
+---
 
-Current release artifacts are `x86_64`.
+## What You Get
 
-| Format | Release-gated targets |
-|--------|-----------------------|
-| AppImage | portable glibc baseline |
-| DEB | Debian 12, Debian 13, Ubuntu 24.04, Ubuntu 26.04 |
-| RPM | Fedora 43, Fedora 44, RHEL/CentOS/Alma/Rocky 10, openSUSE Tumbleweed |
-| AUR | Arch, Manjaro, EndeavourOS, Garuda |
-| Flatpak | GNOME Platform 49, GNOME Platform 50 |
-| Snap | core24, core26 |
-| APK | Alpine 3.20, Alpine 3.22 |
+- Desktop window for Proton Drive with system tray integration
+- Login, CAPTCHA, and two-factor authentication support
+- Proton Drive file browsing and downloads (saved to `~/Downloads`)
+- Native packages for most major Linux distributions
 
-Roadmap patch-ready targets are openSUSE Leap 16 and Alpine 3.23. They are not
-release artifacts yet. See [`docs/packaging.md`](docs/packaging.md).
+## Supported Systems
 
-## Installation
+| Format | Distributions |
+|--------|---------------|
+| **AppImage** | Any Linux with glibc 2.35+ (easiest option for most users) |
+| **DEB** | Debian 12, Debian 13, Ubuntu 24.04, Ubuntu 26.04, Linux Mint 22.x |
+| **RPM** | Fedora 43, Fedora 44, RHEL/CentOS/Alma/Rocky 10, openSUSE Tumbleweed |
+| **AUR** | Arch, Manjaro, EndeavourOS, Garuda |
+| **Flatpak** | GNOME Platform 49, GNOME Platform 50 |
+| **Snap** | core24, core26 |
+| **APK** | Alpine 3.20, Alpine 3.22 (musl) |
+
+All packages are `x86_64`. See [docs/packaging.md](docs/packaging.md) for full compatibility details and roadmap targets (openSUSE Leap 16, Alpine 3.23).
+
+## Install
 
 ### AppImage
 
-The AppImage is the easiest option for most users: download, make executable,
-and run.
+Download, make executable, and run — no installation required:
 
 ```bash
+# Download from https://github.com/DonnieDice/protondrive-linux/releases/latest
 chmod +x proton-drive_*.AppImage
 ./proton-drive_*.AppImage
 ```
 
 ### Debian / Ubuntu / Linux Mint
 
-Choose the DEB that matches your system:
-
-| Package | For |
-|---------|-----|
-| `proton-drive_*_ubuntu24.04_amd64.deb` | Ubuntu 24.04, Linux Mint 22.x, matching Ubuntu-based derivatives |
-| `proton-drive_*_ubuntu26.04_amd64.deb` | Ubuntu 26.04 and matching Ubuntu-based derivatives |
-| `proton-drive_*_debian12_amd64.deb` | Debian 12 |
-| `proton-drive_*_debian13_amd64.deb` | Debian 13 |
-
 ```bash
+# Download the .deb that matches your system from Releases, then:
 sudo apt install ./proton-drive_*.deb
 ```
 
-### Fedora / RHEL / CentOS / Alma / Rocky
+| Package | For |
+|---------|-----|
+| `proton-drive_*_ubuntu24.04_amd64.deb` | Ubuntu 24.04, Linux Mint 22.x, Ubuntu derivatives |
+| `proton-drive_*_ubuntu26.04_amd64.deb` | Ubuntu 26.04 and derivatives |
+| `proton-drive_*_debian12_amd64.deb` | Debian 12 |
+| `proton-drive_*_debian13_amd64.deb` | Debian 13 |
 
-Choose the RPM that matches your system:
+### Fedora / RHEL / openSUSE
+
+```bash
+# Download the .rpm that matches your system from Releases, then:
+sudo dnf install ./proton-drive-*.rpm
+```
 
 | Package | For |
 |---------|-----|
@@ -67,12 +76,7 @@ Choose the RPM that matches your system:
 | `proton-drive-*~el10.x86_64.rpm` | RHEL 10, CentOS Stream 10, Alma 10, Rocky 10 |
 | `proton-drive-*-opensuse-tumbleweed.x86_64.rpm` | openSUSE Tumbleweed |
 
-```bash
-sudo dnf install ./proton-drive-*.rpm
-```
-
-openSUSE Leap 16 RPM is a roadmap target. Use the AppImage on Leap 16 until
-the RPM workflow and smoke test are added.
+openSUSE Leap 16 users: use the AppImage until the Leap 16 RPM is released.
 
 ### Arch / Manjaro / EndeavourOS / Garuda
 
@@ -82,8 +86,7 @@ Install from the AUR:
 yay -S proton-drive
 ```
 
-The AUR package is a native build that compiles against system WebKitGTK. Or
-install a downloaded package directly:
+Or install a downloaded package directly:
 
 ```bash
 sudo pacman -U proton-drive-*.pkg.tar.zst
@@ -92,48 +95,34 @@ sudo pacman -U proton-drive-*.pkg.tar.zst
 ### Flatpak
 
 ```bash
+# Download the .flatpak from Releases, then:
 flatpak install --user proton-drive_*.flatpak
 flatpak run com.proton.drive
 ```
 
-Not currently available on Flathub. Download the `.flatpak` artifact from
-[Releases](https://github.com/DonnieDice/protondrive-linux/releases) and install
-it locally. Flatpak releases target the GNOME Platform runtime because the app
-is GTK/WebKitGTK-based.
+Not yet on Flathub — see the [roadmap](#distribution-storefront-roadmap).
 
 ### Snap
 
 ```bash
+# Download the .snap from Releases, then:
 sudo snap install --dangerous proton-drive_*_core24_amd64.snap
 ```
 
-Not currently available in the Snap Store. Download the `.snap` artifact from
-[Releases](https://github.com/DonnieDice/protondrive-linux/releases) and install
-it locally with `--dangerous`.
+Not yet in the Snap Store — see the [roadmap](#distribution-storefront-roadmap).
 
 ### Alpine
 
-Download the APK artifact for your Alpine version from
-[Releases](https://github.com/DonnieDice/protondrive-linux/releases):
-
 ```bash
+# Download the APK tarball from Releases, then:
 tar -C / -xzf proton-drive_*_alpine3.20_x86_64.tar.gz
 ```
 
-Alpine 3.20 and 3.22 are release-gated. Alpine 3.23 is a roadmap target. Current
-glibc DEB/RPM/AppImage artifacts are not Alpine/musl packages.
-
-## Using The App
-
-Open ProtonDrive Linux from your application launcher, then sign in with your
-Proton account. The app supports login, CAPTCHA, two-factor authentication, and
-normal Proton Drive browsing.
-
-Downloads are saved to `~/Downloads`.
+Alpine 3.20 and 3.22 are release-gated. Alpine 3.23 is a roadmap target. glibc DEB/RPM/AppImage packages are not compatible with Alpine/musl.
 
 ## Troubleshooting
 
-### White Screen Or Startup Crash
+### White Screen or Startup Crash
 
 Try launching with WebKitGTK rendering workarounds:
 
@@ -141,63 +130,46 @@ Try launching with WebKitGTK rendering workarounds:
 WEBKIT_DISABLE_DMABUF_RENDERER=1 WEBKIT_DISABLE_COMPOSITING_MODE=1 ./proton-drive*.AppImage
 ```
 
-This can help on some AMD/Wayland systems affected by WebKitGTK rendering bugs.
+This helps on some AMD/Wayland systems affected by WebKitGTK rendering bugs.
 
-### Login Error, Chunk Loading Error, Or CAPTCHA Freeze
+### Login Error, Chunk Loading Error, or CAPTCHA Freeze
 
-Upgrade to the latest release; these issues are fixed in current builds.
+Upgrade to the latest release — these are fixed in current builds.
 
-### App Stuck On The Loading Screen
+### App Stuck on the Loading Screen
 
-- Check that your internet connection is working.
-- Launch the app from a terminal to see error output.
-- Open a GitHub issue and include the terminal log.
+- Check your internet connection
+- Launch from a terminal to see error output
+- [Open an issue](https://github.com/DonnieDice/protondrive-linux/issues/new) with the terminal log
 
 ## Distribution Storefront Roadmap
 
-Packages are currently distributed as GitHub release artifacts. The goal is to
-publish through native distribution storefronts so users can install and update
-ProtonDrive Linux through their system package manager.
+Packages are currently GitHub release artifacts only. The goal is to publish
+through native distribution storefronts so users can install and update
+ProtonDrive Linux through their system package manager. Track progress in
+[Issue #75](https://github.com/DonnieDice/protondrive-linux/issues/75).
 
-| Storefront | Status | Prerequisites |
+| Storefront | Status | What's needed |
 |------------|--------|---------------|
-| AUR (Arch) | Available | Already published via `publish-aur.yml` |
-| Flathub | Not started | Flathub submission, sandbox review, app ID verification |
-| Snap Store | Not started | Snap Store publisher account, `snapcraft register`, stable channel release |
-| COPR (Fedora) | Not started | COPR project creation, spec file review, Fedora packaging guidelines |
-| PPA (Ubuntu) | Not started | Launchpad PPA creation, GPG key, Debian source package format |
-| OBS (openSUSE) | Not started | openSUSE Build Service project, spec/kiwi file, repository publishing |
+| **AUR** | Published | Already live at [aur.archlinux.org/packages/proton-drive](https://aur.archlinux.org/packages/proton-drive); auto-published via CI |
+| **Flathub** | Not started | Flathub submission, sandbox review, app ID verification |
+| **Snap Store** | Not started | Snap Store publisher account, `snapcraft register`, stable channel release |
+| **COPR** (Fedora) | Not started | COPR project creation, spec file review, Fedora packaging guidelines |
+| **PPA** (Ubuntu) | Not started | Launchpad PPA creation, GPG key, Debian source package format |
+| **OBS** (openSUSE) | Not started | openSUSE Build Service project, spec/kiwi file, repository publishing |
 
-See [`docs/packaging.md`](docs/packaging.md) for detailed compatibility and
-release requirements.
+## Building from Source
 
-## Building From Source
+Most users should [download a release package](https://github.com/DonnieDice/protondrive-linux/releases/latest). Build from source only if you want to test changes or package the app yourself. Full build and packaging details are in [docs/CONTRIBUTING.md](docs/CONTRIBUTING.md).
 
-Most users should download a package from
-[Releases](https://github.com/DonnieDice/protondrive-linux/releases). Build from
-source only if you want to test changes or package the app yourself.
+### Quick Build
 
-### Requirements
-
-- Node.js 20+
-- Rust
-- Git
-- WebKitGTK 4.1 and GTK 3 development packages
+Requirements: Node.js 20+, Rust, Git, WebKitGTK 4.1 + GTK 3 dev packages.
 
 ```bash
-# Fedora
+# Install system dependencies (example for Fedora):
 sudo dnf install webkit2gtk4.1-devel gtk3-devel libayatana-appindicator-gtk3-devel openssl-devel
 
-# Debian / Ubuntu
-sudo apt install libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev libssl-dev
-
-# Arch / Manjaro
-sudo pacman -S webkit2gtk-4.1 gtk3 libayatana-appindicator
-```
-
-### Build
-
-```bash
 git clone https://github.com/DonnieDice/protondrive-linux.git
 cd protondrive-linux
 git clone --depth=1 https://github.com/ProtonMail/WebClients.git WebClients
@@ -206,23 +178,14 @@ npm run build:web
 npm run build:appimage
 ```
 
-Built packages go to `src-tauri/target/release/bundle/`. Release artifacts are
-produced by the package workflows documented in `docs/`.
-
-## How It Works
-
-ProtonDrive Linux wraps Proton Drive's official web frontend in a Tauri WebView.
-A local Rust layer helps the web app communicate with Proton's servers from the
-desktop environment. Authentication, encryption, and file operations are handled
-by Proton's web app.
+Built packages go to `src-tauri/target/release/bundle/`.
 
 ## Contributing
 
-Contributions are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for the
-workflow guide. Detailed build, packaging, and development rules are in
-[docs/CONTRIBUTING.md](docs/CONTRIBUTING.md). Technical packaging and
-compatibility notes are in [`docs/`](docs/).
+Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for the
+workflow guide and [docs/CONTRIBUTING.md](docs/CONTRIBUTING.md) for detailed
+build, packaging, and development rules.
 
 ## License
 
-AGPL-3.0. See [LICENSE](LICENSE).
+AGPL-3.0 or later. See [LICENSE](LICENSE).

--- a/README.md
+++ b/README.md
@@ -1,22 +1,13 @@
 <div align="center">
 
-# ProtonDrive Linux
+<h1><img src="src-tauri/icons/proton-drive.svg" height="28"> ProtonDrive Linux</h1>
+
+[![latest](https://img.shields.io/github/v/release/DonnieDice/protondrive-linux?label=latest&color=6d4aff)](https://github.com/DonnieDice/protondrive-linux/releases/latest)
+[![downloads](https://img.shields.io/github/downloads/DonnieDice/protondrive-linux/total?color=6d4aff)](https://github.com/DonnieDice/protondrive-linux/releases)
+[![license](https://img.shields.io/badge/license-AGPL--3.0-6d4aff)](./LICENSE)
+[![issues](https://img.shields.io/github/issues/DonnieDice/protondrive-linux?color=6d4aff)](https://github.com/DonnieDice/protondrive-linux/issues)
 
 An unofficial desktop client for [Proton Drive](https://proton.me/drive) on Linux.
-
-[![GitHub release](https://img.shields.io/github/v/release/DonnieDice/protondrive-linux?label=latest&color=brightgreen)](https://github.com/DonnieDice/protondrive-linux/releases/latest)
-[![Release CI](https://img.shields.io/github/actions/workflow/status/DonnieDice/protondrive-linux/release.yml?branch=main&label=CI)](https://github.com/DonnieDice/protondrive-linux/actions/workflows/release.yml)
-[![AUR](https://img.shields.io/aur/version/proton-drive?color=blue)](https://aur.archlinux.org/packages/proton-drive)
-[![License](https://img.shields.io/badge/license-AGPL--3.0-blue)](./LICENSE)
-[![GitHub stars](https://img.shields.io/github/stars/DonnieDice/protondrive-linux?style=social)](https://github.com/DonnieDice/protondrive-linux/stargazers)
-[![GitHub forks](https://img.shields.io/github/forks/DonnieDice/protondrive-linux?style=social)](https://github.com/DonnieDice/protondrive-linux/fork)
-[![Platform](https://img.shields.io/badge/platform-Linux-ffb86c)](https://github.com/DonnieDice/protondrive-linux/releases/latest)
-[![Architecture](https://img.shields.io/badge/arch-x86__64-ff79c6)](https://github.com/DonnieDice/protondrive-linux/releases/latest)
-[![Tauri](https://img.shields.io/badge/built%20with-Tauri-24c8d8)](https://tauri.app/)
-[![Rust](https://img.shields.io/badge/written%20in-Rust-dea584)](https://www.rust-lang.org/)
-
-> **Disclaimer:** This project is not affiliated with, endorsed by, or connected to Proton AG.
-> Proton Drive is a trademark of Proton AG. This is an independent community project.
 
 </div>
 
@@ -36,10 +27,18 @@ ProtonDrive Linux wraps the official [Proton Drive](https://proton.me/drive) web
 
 > **Packages are not yet available on Flathub, Snap Store, or system repositories.** For now, download from [Releases](https://github.com/DonnieDice/protondrive-linux/releases/latest).
 
-## Contributing
+## Documentation
 
-Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for the workflow guide and [docs/CONTRIBUTING.md](docs/CONTRIBUTING.md) for detailed build, packaging, and development rules.
+| | |
+|---|---|
+| [Contributing](CONTRIBUTING.md) | Workflow guide |
+| [Build & Packaging](docs/CONTRIBUTING.md) | Detailed dev, build, and packaging rules |
+| [Packaging & Compatibility](docs/packaging.md) | Support matrix, compatibility gates, patch policy |
+| [Changelog](docs/CHANGELOG.md) | Release history |
+| [Security Policy](docs/SECURITY.md) | Vulnerability reporting |
+| [Code of Conduct](docs/CODE_OF_CONDUCT.md) | Community standards |
 
-## License
+&nbsp;
 
-AGPL-3.0 or later. See [LICENSE](LICENSE).
+> **Disclaimer:** This project is not affiliated with, endorsed by, or connected to Proton AG.
+> Proton Drive is a trademark of Proton AG. This is an independent community project.

--- a/README.md
+++ b/README.md
@@ -1,190 +1,44 @@
-# ProtonDrive Linux
+<div align="center">
 
-[![Latest Release](https://img.shields.io/github/v/release/DonnieDice/protondrive-linux?label=latest&color=brightgreen)](https://github.com/DonnieDice/protondrive-linux/releases/latest)
-[![CI](https://img.shields.io/github/actions/workflow/status/DonnieDice/protondrive-linux/release.yml?branch=main&label=release%20CI)](https://github.com/DonnieDice/protondrive-linux/actions/workflows/release.yml)
-[![License](https://img.shields.io/badge/license-AGPL--3.0-blue)](https://github.com/DonnieDice/protondrive-linux)
-[![AUR](https://img.shields.io/aur/version/proton-drive?label=AUR&color=blue)](https://aur.archlinux.org/packages/proton-drive)
+# ProtonDrive Linux
 
 An unofficial desktop client for [Proton Drive](https://proton.me/drive) on Linux.
 
-> **Disclaimer:** This project is not affiliated with, endorsed by, or connected to Proton AG. Proton Drive is a trademark of Proton AG. This is an independent community project that wraps the official Proton Drive web interface in a native Linux desktop window.
+[![GitHub release](https://img.shields.io/github/v/release/DonnieDice/protondrive-linux?label=latest&color=brightgreen)](https://github.com/DonnieDice/protondrive-linux/releases/latest)
+[![Release CI](https://img.shields.io/github/actions/workflow/status/DonnieDice/protondrive-linux/release.yml?branch=main&label=CI)](https://github.com/DonnieDice/protondrive-linux/actions/workflows/release.yml)
+[![AUR](https://img.shields.io/aur/version/proton-drive?color=blue)](https://aur.archlinux.org/packages/proton-drive)
+[![License](https://img.shields.io/badge/license-AGPL--3.0-blue)](./LICENSE)
+[![GitHub stars](https://img.shields.io/github/stars/DonnieDice/protondrive-linux?style=social)](https://github.com/DonnieDice/protondrive-linux/stargazers)
+[![GitHub forks](https://img.shields.io/github/forks/DonnieDice/protondrive-linux?style=social)](https://github.com/DonnieDice/protondrive-linux/fork)
+[![Platform](https://img.shields.io/badge/platform-Linux-ffb86c)](https://github.com/DonnieDice/protondrive-linux/releases/latest)
+[![Architecture](https://img.shields.io/badge/arch-x86__64-ff79c6)](https://github.com/DonnieDice/protondrive-linux/releases/latest)
+[![Tauri](https://img.shields.io/badge/built%20with-Tauri-24c8d8)](https://tauri.app/)
+[![Rust](https://img.shields.io/badge/written%20in-Rust-dea584)](https://www.rust-lang.org/)
+
+> **Disclaimer:** This project is not affiliated with, endorsed by, or connected to Proton AG.
+> Proton Drive is a trademark of Proton AG. This is an independent community project.
+
+</div>
 
 ---
 
-**Packages are not yet available on Flathub, Snap Store, or system repositories.** See the [Distribution Storefront Roadmap](#distribution-storefront-roadmap) for progress. For now, download from [Releases](https://github.com/DonnieDice/protondrive-linux/releases/latest).
+## About
 
----
+ProtonDrive Linux wraps the official [Proton Drive](https://proton.me/drive) web interface in a native Linux desktop window using [Tauri](https://tauri.app/) and [WebKitGTK](https://webkitgtk.org/). Authentication, encryption, and file operations are handled by Proton's web app — this project provides the native shell, system tray integration, and cross-distro packaging.
 
-## What You Get
+**Features:**
 
 - Desktop window for Proton Drive with system tray integration
 - Login, CAPTCHA, and two-factor authentication support
 - Proton Drive file browsing and downloads (saved to `~/Downloads`)
 - Native packages for most major Linux distributions
+- Built with Rust + Tauri for a small footprint and low resource usage
 
-## Supported Systems
-
-| Format | Distributions |
-|--------|---------------|
-| **AppImage** | Any Linux with glibc 2.35+ (easiest option for most users) |
-| **DEB** | Debian 12, Debian 13, Ubuntu 24.04, Ubuntu 26.04, Linux Mint 22.x |
-| **RPM** | Fedora 43, Fedora 44, RHEL/CentOS/Alma/Rocky 10, openSUSE Tumbleweed |
-| **AUR** | Arch, Manjaro, EndeavourOS, Garuda |
-| **Flatpak** | GNOME Platform 49, GNOME Platform 50 |
-| **Snap** | core24, core26 |
-| **APK** | Alpine 3.20, Alpine 3.22 (musl) |
-
-All packages are `x86_64`. See [docs/packaging.md](docs/packaging.md) for full compatibility details and roadmap targets (openSUSE Leap 16, Alpine 3.23).
-
-## Install
-
-### AppImage
-
-Download, make executable, and run — no installation required:
-
-```bash
-# Download from https://github.com/DonnieDice/protondrive-linux/releases/latest
-chmod +x proton-drive_*.AppImage
-./proton-drive_*.AppImage
-```
-
-### Debian / Ubuntu / Linux Mint
-
-```bash
-# Download the .deb that matches your system from Releases, then:
-sudo apt install ./proton-drive_*.deb
-```
-
-| Package | For |
-|---------|-----|
-| `proton-drive_*_ubuntu24.04_amd64.deb` | Ubuntu 24.04, Linux Mint 22.x, Ubuntu derivatives |
-| `proton-drive_*_ubuntu26.04_amd64.deb` | Ubuntu 26.04 and derivatives |
-| `proton-drive_*_debian12_amd64.deb` | Debian 12 |
-| `proton-drive_*_debian13_amd64.deb` | Debian 13 |
-
-### Fedora / RHEL / openSUSE
-
-```bash
-# Download the .rpm that matches your system from Releases, then:
-sudo dnf install ./proton-drive-*.rpm
-```
-
-| Package | For |
-|---------|-----|
-| `proton-drive-*~fedora43.x86_64.rpm` | Fedora 43 |
-| `proton-drive-*~fedora44.x86_64.rpm` | Fedora 44 |
-| `proton-drive-*~el10.x86_64.rpm` | RHEL 10, CentOS Stream 10, Alma 10, Rocky 10 |
-| `proton-drive-*-opensuse-tumbleweed.x86_64.rpm` | openSUSE Tumbleweed |
-
-openSUSE Leap 16 users: use the AppImage until the Leap 16 RPM is released.
-
-### Arch / Manjaro / EndeavourOS / Garuda
-
-Install from the AUR:
-
-```bash
-yay -S proton-drive
-```
-
-Or install a downloaded package directly:
-
-```bash
-sudo pacman -U proton-drive-*.pkg.tar.zst
-```
-
-### Flatpak
-
-```bash
-# Download the .flatpak from Releases, then:
-flatpak install --user proton-drive_*.flatpak
-flatpak run com.proton.drive
-```
-
-Not yet on Flathub — see the [roadmap](#distribution-storefront-roadmap).
-
-### Snap
-
-```bash
-# Download the .snap from Releases, then:
-sudo snap install --dangerous proton-drive_*_core24_amd64.snap
-```
-
-Not yet in the Snap Store — see the [roadmap](#distribution-storefront-roadmap).
-
-### Alpine
-
-```bash
-# Download the APK tarball from Releases, then:
-tar -C / -xzf proton-drive_*_alpine3.20_x86_64.tar.gz
-```
-
-Alpine 3.20 and 3.22 are release-gated. Alpine 3.23 is a roadmap target. glibc DEB/RPM/AppImage packages are not compatible with Alpine/musl.
-
-## Troubleshooting
-
-### White Screen or Startup Crash
-
-Try launching with WebKitGTK rendering workarounds:
-
-```bash
-WEBKIT_DISABLE_DMABUF_RENDERER=1 WEBKIT_DISABLE_COMPOSITING_MODE=1 ./proton-drive*.AppImage
-```
-
-This helps on some AMD/Wayland systems affected by WebKitGTK rendering bugs.
-
-### Login Error, Chunk Loading Error, or CAPTCHA Freeze
-
-Upgrade to the latest release — these are fixed in current builds.
-
-### App Stuck on the Loading Screen
-
-- Check your internet connection
-- Launch from a terminal to see error output
-- [Open an issue](https://github.com/DonnieDice/protondrive-linux/issues/new) with the terminal log
-
-## Distribution Storefront Roadmap
-
-Packages are currently GitHub release artifacts only. The goal is to publish
-through native distribution storefronts so users can install and update
-ProtonDrive Linux through their system package manager. Track progress in
-[Issue #75](https://github.com/DonnieDice/protondrive-linux/issues/75).
-
-| Storefront | Status | What's needed |
-|------------|--------|---------------|
-| **AUR** | Published | Already live at [aur.archlinux.org/packages/proton-drive](https://aur.archlinux.org/packages/proton-drive); auto-published via CI |
-| **Flathub** | Not started | Flathub submission, sandbox review, app ID verification |
-| **Snap Store** | Not started | Snap Store publisher account, `snapcraft register`, stable channel release |
-| **COPR** (Fedora) | Not started | COPR project creation, spec file review, Fedora packaging guidelines |
-| **PPA** (Ubuntu) | Not started | Launchpad PPA creation, GPG key, Debian source package format |
-| **OBS** (openSUSE) | Not started | openSUSE Build Service project, spec/kiwi file, repository publishing |
-
-## Building from Source
-
-Most users should [download a release package](https://github.com/DonnieDice/protondrive-linux/releases/latest). Build from source only if you want to test changes or package the app yourself. Full build and packaging details are in [docs/CONTRIBUTING.md](docs/CONTRIBUTING.md).
-
-### Quick Build
-
-Requirements: Node.js 20+, Rust, Git, WebKitGTK 4.1 + GTK 3 dev packages.
-
-```bash
-# Install system dependencies (example for Fedora):
-sudo dnf install webkit2gtk4.1-devel gtk3-devel libayatana-appindicator-gtk3-devel openssl-devel
-
-git clone https://github.com/DonnieDice/protondrive-linux.git
-cd protondrive-linux
-git clone --depth=1 https://github.com/ProtonMail/WebClients.git WebClients
-npm install
-npm run build:web
-npm run build:appimage
-```
-
-Built packages go to `src-tauri/target/release/bundle/`.
+> **Packages are not yet available on Flathub, Snap Store, or system repositories.** For now, download from [Releases](https://github.com/DonnieDice/protondrive-linux/releases/latest).
 
 ## Contributing
 
-Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for the
-workflow guide and [docs/CONTRIBUTING.md](docs/CONTRIBUTING.md) for detailed
-build, packaging, and development rules.
+Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for the workflow guide and [docs/CONTRIBUTING.md](docs/CONTRIBUTING.md) for detailed build, packaging, and development rules.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ Current release artifacts are `x86_64`.
 | AUR | Arch, Manjaro, EndeavourOS, Garuda |
 | Flatpak | GNOME Platform 49, GNOME Platform 50 |
 | Snap | core24, core26 |
+| APK | Alpine 3.20, Alpine 3.22 |
 
-Roadmap patch-ready targets are openSUSE Leap 16, Alpine
-3.22, and Alpine 3.23. They are not release artifacts yet. See
-[`docs/packaging.md`](docs/packaging.md).
+Roadmap patch-ready targets are openSUSE Leap 16 and Alpine 3.23. They are not
+release artifacts yet. See [`docs/packaging.md`](docs/packaging.md).
 
 ## Installation
 
@@ -71,21 +71,22 @@ Choose the RPM that matches your system:
 sudo dnf install ./proton-drive-*.rpm
 ```
 
-openSUSE Leap 16 RPM is a roadmap target. Use the
-AppImage on Leap 16 until the RPM workflow and smoke test are added.
+openSUSE Leap 16 RPM is a roadmap target. Use the AppImage on Leap 16 until
+the RPM workflow and smoke test are added.
 
 ### Arch / Manjaro / EndeavourOS / Garuda
 
 Install from the AUR:
 
 ```bash
-yay -S proton-drive-bin
+yay -S proton-drive
 ```
 
-Or install a downloaded package directly:
+The AUR package is a native build that compiles against system WebKitGTK. Or
+install a downloaded package directly:
 
 ```bash
-sudo pacman -U proton-drive-bin-*.pkg.tar.zst
+sudo pacman -U proton-drive-*.pkg.tar.zst
 ```
 
 ### Flatpak
@@ -112,8 +113,15 @@ it locally with `--dangerous`.
 
 ### Alpine
 
-Alpine APK packages are roadmap targets. Current glibc DEB/RPM/AppImage
-artifacts are not Alpine/musl packages.
+Download the APK artifact for your Alpine version from
+[Releases](https://github.com/DonnieDice/protondrive-linux/releases):
+
+```bash
+tar -C / -xzf proton-drive_*_alpine3.20_x86_64.tar.gz
+```
+
+Alpine 3.20 and 3.22 are release-gated. Alpine 3.23 is a roadmap target. Current
+glibc DEB/RPM/AppImage artifacts are not Alpine/musl packages.
 
 ## Using The App
 
@@ -144,6 +152,24 @@ Upgrade to the latest release; these issues are fixed in current builds.
 - Check that your internet connection is working.
 - Launch the app from a terminal to see error output.
 - Open a GitHub issue and include the terminal log.
+
+## Distribution Storefront Roadmap
+
+Packages are currently distributed as GitHub release artifacts. The goal is to
+publish through native distribution storefronts so users can install and update
+ProtonDrive Linux through their system package manager.
+
+| Storefront | Status | Prerequisites |
+|------------|--------|---------------|
+| AUR (Arch) | Available | Already published via `publish-aur.yml` |
+| Flathub | Not started | Flathub submission, sandbox review, app ID verification |
+| Snap Store | Not started | Snap Store publisher account, `snapcraft register`, stable channel release |
+| COPR (Fedora) | Not started | COPR project creation, spec file review, Fedora packaging guidelines |
+| PPA (Ubuntu) | Not started | Launchpad PPA creation, GPG key, Debian source package format |
+| OBS (openSUSE) | Not started | openSUSE Build Service project, spec/kiwi file, repository publishing |
+
+See [`docs/packaging.md`](docs/packaging.md) for detailed compatibility and
+release requirements.
 
 ## Building From Source
 
@@ -192,8 +218,10 @@ by Proton's web app.
 
 ## Contributing
 
-Contributions are welcome. See [CONTRIBUTING.md](docs/CONTRIBUTING.md) for
-guidelines. Technical packaging and compatibility notes are in [`docs/`](docs/).
+Contributions are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for the
+workflow guide. Detailed build, packaging, and development rules are in
+[docs/CONTRIBUTING.md](docs/CONTRIBUTING.md). Technical packaging and
+compatibility notes are in [`docs/`](docs/).
 
 ## License
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## 1.4.3 - 2026-05-17
+
+### Changed
+
+- Updated CONTRIBUTING.md to document commit and PR title conventions that
+  match `docs/CONTRIBUTING.md`.
+- Version metadata bumped to 1.4.3.
+
+### Fixed
+
+- Workflow triggers: all 17 build/spec workflows now include `feature/**`,
+  `fix/**`, and `chore/**` branch push triggers plus `pull_request` on `main`,
+  so CI runs automatically on feature branches.
+- Stale artifact cleanup: added `rm -rf` before build steps in 12 non-RPM
+  workflows (RPM workflows already had this from v1.4.2).
+- Normalized `"on":` quoting across all workflow files for consistent YAML
+  parsing.
+- Removed orphaned `dev` branch trigger from the Alpine 3.22 workflow, replaced
+  by `feature/**` glob pattern.
+- Pinned WebClients ref across all workflows for reproducible builds.
+- Fixed stale artifact filter and deregistered worktree in release workflow.
+
 ## 1.4.2 - 2026-05-16
 
 ### Added

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -151,9 +151,9 @@ Commit with a clear, linkable title:
 git commit -m "(#123) Add system tray icon support"
 ```
 
-Use the issue number at the front of the title when the commit is not itself
-a squash-merge PR title. If the work is not tracked yet, open an issue first
-and use that number. Do not leave the commit title without a GitHub reference.
+The number in the commit title is the **issue** number (e.g., `#123`), not the
+PR number. If the work is not tracked yet, open an issue first and use that
+number. Do not leave the commit title without a GitHub reference.
 
 If you also want body traceability, reference the issue in the body or footer:
 
@@ -175,6 +175,8 @@ All PR titles must match the CommitCheck regex: `^\(#\d+\)\s[A-Z].{9,}$`
 
 Rules:
 
+- The number in the PR title is the **PR** number (assigned by GitHub after
+  you open the PR), not the issue number
 - Start with an uppercase letter
 - Be at least 10 characters long (after the PR number prefix)
 - Put the PR number prefix at the start of the title, e.g. `(#42) Title here`
@@ -192,11 +194,11 @@ will need their titles updated before merging if they don't conform.
 
 ### Commit Message and Link Rules
 
-- Use the commit title for a clear imperative summary plus an issue number
+- Use the commit title for a clear imperative summary plus an **issue** number
   prefix when the commit is not a squash-merge PR title.
 - Use the commit body or footer for extra traceability if needed
   (`Refs #123` or `Closes #123`).
-- Use the PR title for the PR number prefix (`(#123) ...`).
+- Use the PR title for the **PR** number prefix (`(#123) ...`).
 - Do not link file diffs or fake PR numbers in commit titles.
 - If there is no issue yet, create one before writing the commit title.
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -158,7 +158,7 @@ number. Do not leave the commit title without a GitHub reference.
 If you also want body traceability, reference the issue in the body or footer:
 
 ```bash
-git commit -m "Add system tray icon support" -m "Refs #123"
+git commit -m "(#123) Add system tray icon support" -m "Refs #123"
 ```
 
 Use `Closes #123` when the commit fully resolves the issue.
@@ -197,7 +197,7 @@ gh api repos/DonnieDice/protondrive-linux/pulls/NUMBER/files \
 Do **not** fabricate or guess the diff hashes — always fetch them from the
 API. Each link follows the pattern:
 
-```
+```text
 https://github.com/DonnieDice/protondrive-linux/pull/NUMBER/files#diff-{SHA}
 ```
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -172,22 +172,34 @@ git push origin feature/my-feature
 ### PR Body Format
 
 Reference the issue at the top, then list each changed file with a GitHub
-permalink so reviewers can jump directly to the source:
+diff anchor so reviewers can jump directly to that file's diff in the PR:
 
 ```markdown
 Issue: #42
 
 ## Changes
 
-### [`README.md`](https://github.com/DonnieDice/protondrive-linux/blob/<branch>/README.md) — description of changes
+### [`README.md`](https://github.com/DonnieDice/protondrive-linux/pull/47/files#diff-abc123) — description of changes
 - Bullet list of what changed in this file
 
-### [`docs/packaging.md`](https://github.com/DonnieDice/protondrive-linux/blob/<branch>/docs/packaging.md) — description of changes
+### [`docs/packaging.md`](https://github.com/DonnieDice/protondrive-linux/pull/47/files#diff-def456) — description of changes
 - Bullet list of what changed in this file
 ```
 
-Replace `<branch>` with your feature branch name. Each changed file gets its
-own `###` heading with a GitHub blob link and a brief summary of what changed.
+The `#diff-` anchor is the file's SHA from the PR files API. To get the
+real SHAs before editing the PR body:
+
+```bash
+gh api repos/DonnieDice/protondrive-linux/pulls/NUMBER/files \
+  --jq '.[] | .filename + " " + .sha'
+```
+
+Do **not** fabricate or guess the diff hashes — always fetch them from the
+API. Each link follows the pattern:
+
+```
+https://github.com/DonnieDice/protondrive-linux/pull/NUMBER/files#diff-{SHA}
+```
 
 ### PR Title Format
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -169,6 +169,26 @@ Push and open a pull request:
 git push origin feature/my-feature
 ```
 
+### PR Body Format
+
+Reference the issue at the top, then list each changed file with a GitHub
+permalink so reviewers can jump directly to the source:
+
+```markdown
+Issue: #42
+
+## Changes
+
+### [`README.md`](https://github.com/DonnieDice/protondrive-linux/blob/<branch>/README.md) — description of changes
+- Bullet list of what changed in this file
+
+### [`docs/packaging.md`](https://github.com/DonnieDice/protondrive-linux/blob/<branch>/docs/packaging.md) — description of changes
+- Bullet list of what changed in this file
+```
+
+Replace `<branch>` with your feature branch name. Each changed file gets its
+own `###` heading with a GitHub blob link and a brief summary of what changed.
+
 ### PR Title Format
 
 All PR titles must match the CommitCheck regex: `^\(#\d+\)\s[A-Z].{9,}$`

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,8 @@ Project documentation lives here. The root `README.md` is kept as the GitHub lan
 ## Packaging
 
 - [Packaging, Compatibility, And Release](packaging.md)
+- [Release Checklist](release-checklist.md)
+- [New Build/Package Checklist](new-build-checklist.md)
 
 ## Debugging
 

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -84,13 +84,14 @@ described above. Both must pass for a target to be `release-gated`.
 | Snap core26 | runtime | runtime | `build-snap.core26.yml` / `snap-package-core26` | `snap/core26.patch` | remote artifact pass | Snap core26 base | keep in release gate |
 | AUR Arch package (native build) | pass (glibc 2.39) | pass | `build-aur.yml` / `aur-arch-native` | `aur/arch-native.patch` | remote artifact pass | Arch, Manjaro, EndeavourOS, Garuda | keep in release gate |
 | Alpine 3.20 APK | musl pass | pass | `build-apk.alpine.3.20.yml` / `apk-package-alpine320` | `apk/alpine.3.20.patch` | local smoke pass | Alpine 3.20 musl; glibc artifacts are not compatible | keep in release gate |
+| Alpine 3.22 APK | musl pass | pass | `build-apk.alpine.3.22.yml` / `apk-package-alpine322` | `apk/alpine.3.22.patch` | local smoke pass | Alpine 3.22 musl; glibc artifacts are not compatible | keep in release gate |
 
 ### Roadmap patch-ready targets
 
 | Package target | glibc gate | WebKitGTK gate | Workflow / artifact | Patch | Runtime smoke | Covered systems / rule | Next action |
 |----------------|-----------|----------------|---------------------|-------|---------------|------------------------|-------------|
 | openSUSE Leap 16 RPM | pass | pass | none yet / `rpm-package-opensuse-leap16` planned | `rpm/opensuse.leap.16.patch` | no release artifact | openSUSE Leap 16 | add zypper workflow, release artifact, and runtime smoke |
-| Alpine 3.23 APK | musl pass | pass | none yet / `apk-package-alpine323` planned | `apk/alpine.3.23.patch` | no release artifact | Alpine 3.23 musl; glibc artifacts are not compatible | add APK/musl workflow, release artifact, and runtime smoke |
+| Alpine 3.23 APK | musl pass | pass | `build-apk.alpine.3.23.yml` / `apk-package-alpine323` | `apk/alpine.3.23.patch` | no release artifact | Alpine 3.23 musl; glibc artifacts are not compatible | add release artifact and runtime smoke |
 
 ### Roadmap targets (no patch yet)
 
@@ -116,6 +117,7 @@ described above. Both must pass for a target to be `release-gated`.
 | Debian 11 DEB | fail (2.31) | fail | Both gates fail; glibc too old and no WebKitGTK 4.1 | none |
 | EL8 RPM | fail (2.28) | fail | Both gates fail; glibc too old and no WebKitGTK 4.1 | none |
 | Alpine 3.20 APK | promoted | pass | Promoted to release-gated on 2026-05-16; CI green, smoke test passed on Alpine 3.20 host | none (now in release-gated) |
+| Alpine 3.22 APK | promoted | pass | Promoted to release-gated on 2026-05-16; CI green, smoke test passed on Alpine 3.22 host | none (now in release-gated) |
 
 ## Architecture Plan
 
@@ -136,9 +138,10 @@ described above. Both must pass for a target to be `release-gated`.
 - RHEL 10, CentOS Stream 10, AlmaLinux 10, and Rocky Linux 10 share the EL10 RPM
   line.
 - openSUSE Tumbleweed users use the Tumbleweed RPM. Leap 16 users should use AppImage until a Leap 16 RPM workflow and smoke test are added.
-- Alpine users need APK/musl packages. Alpine 3.20 has WebKitGTK 4.1
-  available in repos. Current glibc DEB/RPM/AppImage artifacts are not
-  Alpine-compatible.
+- Alpine users need APK/musl packages. Alpine 3.20 and 3.22 have WebKitGTK
+4.1 available in repos and are release-gated. Alpine 3.23 has a CI workflow
+but is not yet release-gated. Current glibc DEB/RPM/AppImage artifacts are not
+Alpine-compatible.
 - Flatpak releases target GNOME Platform runtimes because the app is
   GTK/WebKitGTK-based.
 - Nix users will use a future Nix flake that manages both libc and WebKitGTK

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -38,6 +38,7 @@ Use this checklist before every release deployment.
 - [ ] AUR workflow is passing.
 - [ ] APK Alpine 3.20 workflow is passing.
 - [ ] APK Alpine 3.22 workflow is passing.
+- [ ] APK Alpine 3.23 workflow is passing (roadmap patch-ready target).
 - [ ] Release workflow is passing.
 
 - [ ] Merge approved PRs into `main`.

--- a/opencode.json
+++ b/opencode.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "instructions": [".opencode/agent/protondrive-conventions.md", "CONTRIBUTING.md"]
+}

--- a/packaging/compatibility-map.yml
+++ b/packaging/compatibility-map.yml
@@ -330,21 +330,20 @@ roadmap_patch_ready:
       rustflags = ["-C", "target-feature=-crt-static"]
     supports:
     - alpine-3.22
-    alpine323:
-      status: roadmap-patch-ready
-      gates:
-        glibc: musl-pass
-        webkitgtk: pass
-      workflow: null
-      build_container: alpine:3.23
-      release_label: alpine323
-      artifact_name: apk-package-alpine323
-      patch: alpine.3.23
-      supports:
-      - alpine-3.23
-      before_release_gate:
-      - add APK packaging workflow
-      - validate musl runtime install and login smoke test
+  alpine323:
+    status: roadmap-patch-ready
+    gates:
+      glibc: musl-pass
+      webkitgtk: pass
+    workflow: .github/workflows/build-apk.alpine.3.23.yml
+    build_container: alpine:3.23
+    release_label: alpine323
+    artifact_name: apk-package-alpine323
+    patch: alpine.3.23
+    supports:
+    - alpine-3.23
+    before_release_gate:
+    - validate musl runtime install and login smoke test
 
 roadmap:
   nix:

--- a/patches/README.md
+++ b/patches/README.md
@@ -58,8 +58,8 @@ These are currently built and published by the release workflow:
 - `rpm/fedora.43.patch`
 - `rpm/fedora.44.patch`
 - `rpm/opensuse.tumbleweed.patch`
-- `apk/alpine.3.20.patch`
 - `apk/alpine.3.22.patch`
+- `apk/alpine.3.20.patch`
 - `snap/core24.patch`
 - `snap/core26.patch`
 
@@ -74,10 +74,8 @@ are not release-gated yet.
 
 | Patch | Target | Required before publishing |
 |-------|--------|----------------------------|
-| `rpm/opensuse.tumbleweed.patch` | openSUSE Tumbleweed | zypper RPM workflow, artifact upload, runtime smoke test |
 | `rpm/opensuse.leap.16.patch` | openSUSE Leap 16 | zypper RPM workflow, artifact upload, runtime smoke test |
-| `apk/alpine.3.22.patch` | Alpine 3.22 musl | promoted to release-gated in v1.4.1; no further action needed |
-| `apk/alpine.3.23.patch` | Alpine 3.23 musl | APK packaging workflow, artifact upload, musl runtime smoke test |
+| `apk/alpine.3.23.patch` | Alpine 3.23 musl | release artifact integration, musl runtime smoke test |
 
 No optional desktop-runtime variants or older GNOME Flatpak patches are
 tracked. Flatpak releases target GNOME Platform runtimes because the app is

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2858,7 +2858,7 @@ dependencies = [
 
 [[package]]
 name = "proton-drive"
-version = "1.4.2"
+version = "1.4.3"
 dependencies = [
  "base64 0.22.1",
  "dirs",


### PR DESCRIPTION
Issue: #75

## Changes

### [`README.md`](https://github.com/DonnieDice/protondrive-linux/pull/76/files#diff-39534a5d1ef24928efffb74ce4b22fb866faa111) — user-facing rewrite
- Badges: latest release, CI status, license, AUR version
- Clear disclaimer: not affiliated with Proton AG, independent community project
- Prominent callout: packages NOT yet on Flathub/Snap Store/repos, with link to storefront roadmap
- User-first structure: What You Get, Supported Systems, Install, Troubleshooting before any technical content
- Direct links to latest release throughout install sections
- Distribution Storefront Roadmap section with Issue #75 link for tracking, AUR direct link
- AUR package name fixed: `proton-drive` (native build), not `proton-drive-bin`
- Alpine install instructions with actual command
- Build from source moved below the fold, trimmed to quick build with pointer to docs
- CONTRIBUTING links: root `CONTRIBUTING.md` first, then `docs/CONTRIBUTING.md`

### [`LICENSE`](https://github.com/DonnieDice/protondrive-linux/pull/76/files#diff-823575bc6eb62753576cc82f8b4c120e36c589a5) — added
- Full AGPL-3.0 license text with copyright notice (was missing from repo)

### [`CONTRIBUTING.md`](https://github.com/DonnieDice/protondrive-linux/pull/76/files#diff-30af92197d53d09432424663a2b5b94aec6cdd16) — issue vs PR number, PR body format
- Commit titles use the **issue** number
- PR titles use the **PR** number (assigned by GitHub after creation)
- Added PR body format: each changed file gets its own `###` heading with a diff link

### [`docs/CONTRIBUTING.md`](https://github.com/DonnieDice/protondrive-linux/pull/76/files#diff-88d8e890f1d8927d1566e1e52a9095765d013c62) — issue vs PR number, PR body format
- Same issue vs PR number distinction added
- Same PR body file-link format added
- Commit message and link rules updated to bold which number goes where

### [`docs/packaging.md`](https://github.com/DonnieDice/protondrive-linux/pull/76/files#diff-9c57ee80fbc4d731ea7b14fc7a169491458baf8d) — consistency fixes
- Alpine 3.22 added to release-gated table
- Alpine 3.23 workflow updated from `none yet` to actual name
- Alpine 3.22 added to not-primary promoted entries
- Compatibility rules updated for Alpine 3.20 + 3.22 release-gated status

### [`packaging/compatibility-map.yml`](https://github.com/DonnieDice/protondrive-linux/pull/76/files#diff-b24c3c7ded714a0db00d1189697a92a1d981749a) — workflow fix
- Alpine 3.23 `workflow: null` → actual workflow path
- Removed stale `add APK packaging workflow` from before_release_gate

### [`patches/README.md`](https://github.com/DonnieDice/protondrive-linux/pull/76/files#diff-79a1d35119bb494a57c0549ce7e4c8289361d3a8) — stale entries removed
- Removed openSUSE Tumbleweed and Alpine 3.22 from roadmap table (both already release-gated)
- Updated Alpine 3.23 prerequisites to reflect existing workflow

### [`docs/CHANGELOG.md`](https://github.com/DonnieDice/protondrive-linux/pull/76/files#diff-780fd58089f2f0c4e85bbd00c5b00b50e61e42c6) — missing entry added
- Added v1.4.3 entry covering workflow triggers, stale artifact cleanup, CONTRIBUTING.md fixes, WebClients pin

### [`docs/README.md`](https://github.com/DonnieDice/protondrive-linux/pull/76/files#diff-cdd72ec0732cdd86c91a9751b836ba84f700b447) — index completed
- Added links to release-checklist.md and new-build-checklist.md

### [`docs/release-checklist.md`](https://github.com/DonnieDice/protondrive-linux/pull/76/files#diff-5ce36aa89570594266c75b772bbcf29a725107a9) — workflow check added
- Added Alpine 3.23 workflow check (roadmap patch-ready target)

### [`.opencode/agent/protondrive-conventions.md`](https://github.com/DonnieDice/protondrive-linux/pull/76/files#diff-8b39ce4db40bd42539edc8f796e116f232fb7439) — agent config
- Project conventions: commit messages, PR titles, PR body format, branching, version bumps
- Loaded as opencode instructions for every session

### [`opencode.json`](https://github.com/DonnieDice/protondrive-linux/pull/76/files#diff-23466eb42b541b1bb1f482b2f97fe1b70b3ac4e1) — opencode config
- References agent conventions file and root CONTRIBUTING.md as instructions