### PR TITLE
(#78) Wire Alpine 3.23 APK into release pipeline and promote to release-gated

### DIFF
--- a/.github/workflows/build-apk.alpine.3.22.yml
+++ b/.github/workflows/build-apk.alpine.3.22.yml
@@ -110,13 +110,13 @@ jobs:
           echo "WARNING: $PATCH_FILE not found, building without distro patch"
         fi
 
-- name: Build APK
-  run: |
-    if [ -f "$HOME/.cargo/env" ]; then . "$HOME/.cargo/env"; fi
-    export PKG_CONFIG_ALLOW_CROSS=1
-    export PKG_CONFIG_PATH="/usr/lib/pkgconfig:/usr/share/pkgconfig"
-    rm -rf /tmp/apk-artifact
-    scripts/build-webclients.sh
+    - name: Build APK
+      run: |
+        if [ -f "$HOME/.cargo/env" ]; then . "$HOME/.cargo/env"; fi
+        export PKG_CONFIG_ALLOW_CROSS=1
+        export PKG_CONFIG_PATH="/usr/lib/pkgconfig:/usr/share/pkgconfig"
+        rm -rf /tmp/apk-artifact
+        scripts/build-webclients.sh
         VERSION=$(node -p "require('./package.json').version")
         sed -i "s/\"version\": \"[^\"]*\"/\"version\": \"$VERSION\"/" src-tauri/tauri.conf.json
         sed -i "0,/^version = \"[^\"]*\"/s//version = \"$VERSION\"/" src-tauri/Cargo.toml

--- a/.github/workflows/build-apk.alpine.3.23.yml
+++ b/.github/workflows/build-apk.alpine.3.23.yml
@@ -89,10 +89,10 @@ jobs:
         rustflags = ["-C", "target-feature=-crt-static"]
         EOF
         echo "Created .cargo/config.toml:"
-    cat .cargo/config.toml
-    git config --global --add safe.directory "$GITHUB_WORKSPACE"
+        cat .cargo/config.toml
+        git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
-- name: Clone WebClients
+    - name: Clone WebClients
       run: |
         git clone --depth=1 --single-branch --branch "${WEBCLIENTS_REF}" https://github.com/ProtonMail/WebClients.git WebClients
 
@@ -111,13 +111,13 @@ jobs:
           echo "WARNING: $PATCH_FILE not found, building without distro patch"
         fi
 
-- name: Build APK
-  run: |
-    if [ -f "$HOME/.cargo/env" ]; then . "$HOME/.cargo/env"; fi
-    export PKG_CONFIG_ALLOW_CROSS=1
-    export PKG_CONFIG_PATH="/usr/lib/pkgconfig:/usr/share/pkgconfig"
-    rm -rf /tmp/apk-artifact
-    scripts/build-webclients.sh
+    - name: Build APK
+      run: |
+        if [ -f "$HOME/.cargo/env" ]; then . "$HOME/.cargo/env"; fi
+        export PKG_CONFIG_ALLOW_CROSS=1
+        export PKG_CONFIG_PATH="/usr/lib/pkgconfig:/usr/share/pkgconfig"
+        rm -rf /tmp/apk-artifact
+        scripts/build-webclients.sh
         VERSION=$(node -p "require('./package.json').version")
         sed -i "s/\"version\": \"[^\"]*\"/\"version\": \"$VERSION\"/" src-tauri/tauri.conf.json
         sed -i "0,/^version = \"[^\"]*\"/s//version = \"$VERSION\"/" src-tauri/Cargo.toml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,6 +79,7 @@ jobs:
               'Build RPM openSUSE Tumbleweed',
               'Build APK Alpine 3.20',
               'Build APK Alpine 3.22',
+              'Build APK Alpine 3.23',
             ];
             await new Promise(resolve => setTimeout(resolve, 30000));
             const maxAttempts = 75;
@@ -272,6 +273,16 @@ jobs:
           workflow_conclusion: success
           if_no_artifact_found: fail
 
+      - name: Download APK Alpine 3.23 artifact
+        uses: dawidd6/action-download-artifact@v6
+        with:
+          workflow: build-apk.alpine.3.23.yml
+          name: apk-package-alpine323
+          path: artifacts/apk-alpine323
+          commit: ${{ github.sha }}
+          workflow_conclusion: success
+          if_no_artifact_found: fail
+
       - name: Prepare release files
         run: |
           VERSION=$(node -p "require('./package.json').version")
@@ -304,6 +315,9 @@ jobs:
                 dest="release/${name}"
                 ;;
               apk-alpine322/*)
+                dest="release/${name}"
+                ;;
+             apk-alpine323/*)
                 dest="release/${name}"
                 ;;
               *)
@@ -350,6 +364,7 @@ jobs:
           | RPM (openSUSE Tumbleweed) | \`proton-drive-*-opensuse-tumbleweed.rpm\` | openSUSE Tumbleweed (rolling) |
           | APK (Alpine 3.20) | \`proton-drive_*_alpine320_amd64.apk.tar.gz\` | Alpine 3.20 (musl) |
           | APK (Alpine 3.22) | \`proton-drive_*_alpine322_amd64.apk.tar.gz\` | Alpine 3.22 (musl) |
+ | APK (Alpine 3.23) | `proton-drive_*_alpine323_amd64.apk.tar.gz` | Alpine 3.23 (musl) |
 
           ## Installation
 
@@ -398,6 +413,11 @@ jobs:
           \`\`\`bash
           sudo apk add ./proton-drive_*_alpine322_amd64.apk.tar.gz
           \`\`\`
+
+### Alpine 3.23
+```bash
+sudo apk add ./proton-drive_*_alpine323_amd64.apk.tar.gz
+```
 
           ## Checksums
 

--- a/docs/new-build-checklist.md
+++ b/docs/new-build-checklist.md
@@ -204,5 +204,19 @@ available in a minimal Alpine container. For APK targets, use `cargo build
 --release` directly instead of `npx tauri build`, since APK packaging is
 handled in a separate step.
 - **APKBUILD is a file, not a directory**: When creating the APK staging
-directory, do not `mkdir -p "$STAGING/APKBUILD"` — that creates APKBUILD as
-a directory. The APKBUILD should be written as a file with `cat >`.
+  directory, do not `mkdir -p "$STAGING/APKBUILD"` — that creates APKBUILD as
+  a directory. The APKBUILD should be written as a file with `cat >`.
+- **D-Bus session bus on Alpine (CRITICAL)**: Alpine musl lacks systemd's
+  D-Bus auto-launching. If `DBUS_SESSION_BUS_ADDRESS` points to an
+  inaccessible socket (e.g., owned by lightdm/root), WebKitWebProcess will
+  SIGABRT in `g_dbus_address_get_stream_sync()` due to a GLib bug where the
+  `autolaunch:` fallback path can fail without setting a GError. The patch
+  must auto-launch a user D-Bus session via `dbus-launch --sh-syntax` if the
+  inherited bus is not accessible, set `AT_SPI_BUS_ADDRESS=/dev/null` to
+  prevent the accessibility bus from crashing, and create `XDG_RUNTIME_DIR`
+  if missing. This affects all Alpine APK targets (3.20, 3.22, 3.23).
+- **`AT_SPI_BUS_ADDRESS` on Alpine**: The accessibility bus socket inherited
+  from a display manager (e.g., lightdm) is typically not accessible to the
+  user. Setting `AT_SPI_BUS_ADDRESS=/dev/null` prevents WebKitWebProcess from
+  attempting to connect and crashing. This produces a harmless warning but
+  avoids the SIGABRT.

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -85,13 +85,13 @@ described above. Both must pass for a target to be `release-gated`.
 | AUR Arch package (native build) | pass (glibc 2.39) | pass | `build-aur.yml` / `aur-arch-native` | `aur/arch-native.patch` | remote artifact pass | Arch, Manjaro, EndeavourOS, Garuda | keep in release gate |
 | Alpine 3.20 APK | musl pass | pass | `build-apk.alpine.3.20.yml` / `apk-package-alpine320` | `apk/alpine.3.20.patch` | local smoke pass | Alpine 3.20 musl; glibc artifacts are not compatible | keep in release gate |
 | Alpine 3.22 APK | musl pass | pass | `build-apk.alpine.3.22.yml` / `apk-package-alpine322` | `apk/alpine.3.22.patch` | local smoke pass | Alpine 3.22 musl; glibc artifacts are not compatible | keep in release gate |
+| Alpine 3.23 APK | musl pass | pass | `build-apk.alpine.3.23.yml` / `apk-package-alpine323` | `apk/alpine.3.23.patch` | local smoke pass | Alpine 3.23 musl; glibc artifacts are not compatible | keep in release gate |
 
 ### Roadmap patch-ready targets
 
 | Package target | glibc gate | WebKitGTK gate | Workflow / artifact | Patch | Runtime smoke | Covered systems / rule | Next action |
 |----------------|-----------|----------------|---------------------|-------|---------------|------------------------|-------------|
 | openSUSE Leap 16 RPM | pass | pass | none yet / `rpm-package-opensuse-leap16` planned | `rpm/opensuse.leap.16.patch` | no release artifact | openSUSE Leap 16 | add zypper workflow, release artifact, and runtime smoke |
-| Alpine 3.23 APK | musl pass | pass | `build-apk.alpine.3.23.yml` / `apk-package-alpine323` | `apk/alpine.3.23.patch` | no release artifact | Alpine 3.23 musl; glibc artifacts are not compatible | add release artifact and runtime smoke |
 
 ### Roadmap targets (no patch yet)
 
@@ -138,10 +138,9 @@ described above. Both must pass for a target to be `release-gated`.
 - RHEL 10, CentOS Stream 10, AlmaLinux 10, and Rocky Linux 10 share the EL10 RPM
   line.
 - openSUSE Tumbleweed users use the Tumbleweed RPM. Leap 16 users should use AppImage until a Leap 16 RPM workflow and smoke test are added.
-- Alpine users need APK/musl packages. Alpine 3.20 and 3.22 have WebKitGTK
-4.1 available in repos and are release-gated. Alpine 3.23 has a CI workflow
-but is not yet release-gated. Current glibc DEB/RPM/AppImage artifacts are not
-Alpine-compatible.
+- Alpine users need APK/musl packages. Alpine 3.20, 3.22, and 3.23 have
+WebKitGTK 4.1 available in repos and are release-gated. Current glibc
+DEB/RPM/AppImage artifacts are not Alpine-compatible.
 - Flatpak releases target GNOME Platform runtimes because the app is
   GTK/WebKitGTK-based.
 - Nix users will use a future Nix flake that manages both libc and WebKitGTK
@@ -215,7 +214,8 @@ Runtime settings by baseline:
 | EL10 | same current-WebKitGTK path as Fedora |
 | openSUSE Tumbleweed | sandbox disable, `JSC_useWasmIPInt=false`, `GDK_GL=disable`, `LIBGL_ALWAYS_SOFTWARE=1`, `GSK_RENDERER=cairo` |
 | Alpine 3.20 APK | musl package target; `WEBKIT_DISABLE_DMABUF_RENDERER=1`, `WEBKIT_DISABLE_COMPOSITING_MODE=1`, `WEBKIT_DISABLE_SANDBOX_THIS_IS_DANGEROUS=1`, `JSC_useWasmIPInt=false`, `GDK_GL=disable`, `LIBGL_ALWAYS_SOFTWARE=1`, `GSK_RENDERER=cairo` |
-| Alpine 3.23 roadmap | musl package target plus current-WebKitGTK conservative path |
+| Alpine 3.22 APK | Alpine 3.20 settings plus D-Bus session auto-launch, `AT_SPI_BUS_ADDRESS=/dev/null`, `XDG_RUNTIME_DIR` auto-create |
+| Alpine 3.23 APK | Alpine 3.22 settings (same D-Bus/at-spi/XDG workarounds) |
 | Flatpak GNOME 49/50 | runtime-specific WebKitGTK settings for GNOME Platform targets |
 | Snap core24/core26 | wrapper/manifest WebKit paths plus package patch behavior |
 | AUR (native) | sandbox disable, `JSC_useWasmIPInt=false`; hardware rendering kept |
@@ -249,7 +249,7 @@ Release checklist:
   `packaging/compatibility-map.yml`.
 - `main` contains only the tested commits intended for release.
 - Release tag points at `main`.
-- GitHub release contains all 16 release-gated artifacts plus `SHA256SUMS`.
+- GitHub release contains all 17 release-gated artifacts plus `SHA256SUMS`.
 
 Promotion checklist for roadmap targets:
 

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -38,7 +38,7 @@ Use this checklist before every release deployment.
 - [ ] AUR workflow is passing.
 - [ ] APK Alpine 3.20 workflow is passing.
 - [ ] APK Alpine 3.22 workflow is passing.
-- [ ] APK Alpine 3.23 workflow is passing (roadmap patch-ready target).
+- [ ] APK Alpine 3.23 workflow is passing.
 - [ ] Release workflow is passing.
 
 - [ ] Merge approved PRs into `main`.

--- a/packaging/compatibility-map.yml
+++ b/packaging/compatibility-map.yml
@@ -331,19 +331,24 @@ roadmap_patch_ready:
     supports:
     - alpine-3.22
   alpine323:
-    status: roadmap-patch-ready
+    status: release-gated
     gates:
       glibc: musl-pass
       webkitgtk: pass
+    runtime_smoke:
+      status: pass
+      evidence: CI artifact installed and launched on Alpine 3.23 host, Proton login API responded, D-Bus session auto-launch and AT_SPI_BUS_ADDRESS=/dev/null workaround applied
     workflow: .github/workflows/build-apk.alpine.3.23.yml
     build_container: alpine:3.23
     release_label: alpine323
     artifact_name: apk-package-alpine323
     patch: alpine.3.23
+    cargo_config: |
+      [target.x86_64-unknown-linux-musl]
+      linker = "gcc"
+      rustflags = ["-C", "target-feature=-crt-static"]
     supports:
-    - alpine-3.23
-    before_release_gate:
-    - validate musl runtime install and login smoke test
+      - alpine-3.23
 
 roadmap:
   nix:

--- a/patches/README.md
+++ b/patches/README.md
@@ -58,8 +58,9 @@ These are currently built and published by the release workflow:
 - `rpm/fedora.43.patch`
 - `rpm/fedora.44.patch`
 - `rpm/opensuse.tumbleweed.patch`
-- `apk/alpine.3.22.patch`
 - `apk/alpine.3.20.patch`
+- `apk/alpine.3.22.patch`
+- `apk/alpine.3.23.patch`
 - `snap/core24.patch`
 - `snap/core26.patch`
 
@@ -75,7 +76,6 @@ are not release-gated yet.
 | Patch | Target | Required before publishing |
 |-------|--------|----------------------------|
 | `rpm/opensuse.leap.16.patch` | openSUSE Leap 16 | zypper RPM workflow, artifact upload, runtime smoke test |
-| `apk/alpine.3.23.patch` | Alpine 3.23 musl | release artifact integration, musl runtime smoke test |
 
 No optional desktop-runtime variants or older GNOME Flatpak patches are
 tracked. Flatpak releases target GNOME Platform runtimes because the app is

--- a/patches/apk/alpine.3.20.patch
+++ b/patches/apk/alpine.3.20.patch
@@ -1,16 +1,48 @@
 diff --git a/src-tauri/src/main.rs b/src-tauri/src/main.rs
-index 51d68ebd..a3f7c2d4 100644
+index 51d68ebd..9fc477ca 100644
 --- a/src-tauri/src/main.rs
 +++ b/src-tauri/src/main.rs
-@@ -194,9 +194,15 @@ async fn proxy_request(
+@@ -194,9 +194,47 @@ async fn proxy_request(
  }
-
+ 
  fn main() {
 -    // NOTE: WebKitGTK env vars (GDK_GL, WEBKIT_DISABLE_*, etc.) are NOT set here.
 -    // They are distro-specific and belong in patches/<package>/<distro>.patch
 -    // and the package's AppRun/wrapper script. The base binary ships clean.
-+    // WebKitGTK environment for Alpine 3.20 APK builds.
-+    // Alpine is musl-based, so APK support must be built and tested separately.
++    // WebKitGTK environment for Alpine 3.20 (musl) APK builds.
++    // Alpine musl lacks systemd D-Bus auto-launching, so we must provide
++    // a working session bus or WebKitWebProcess will SIGABRT in
++    // g_dbus_address_get_stream_sync() when the inherited bus socket
++    // is inaccessible (e.g. owned by lightdm/root).
++    {
++        let bus = std::env::var("DBUS_SESSION_BUS_ADDRESS").unwrap_or_default();
++        let bus_accessible = bus.starts_with("unix:path=")
++            && std::path::Path::new(&bus["unix:path=".len()..]).exists();
++        if !bus_accessible {
++            if let Ok(output) = std::process::Command::new("dbus-launch")
++                .arg("--sh-syntax")
++                .output()
++            {
++                for line in String::from_utf8_lossy(&output.stdout).lines() {
++                    if line.starts_with("DBUS_SESSION_BUS_ADDRESS=") {
++                        let addr = line
++                            .trim_start_matches("DBUS_SESSION_BUS_ADDRESS=")
++                            .trim_matches('\'')
++                            .trim_end_matches(';');
++                        std::env::set_var("DBUS_SESSION_BUS_ADDRESS", addr);
++                    }
++                }
++            }
++        }
++        if std::env::var("XDG_RUNTIME_DIR").is_err() {
++            if let Ok(user) = std::env::var("USER") {
++                let dir = format!("/tmp/runtime-{}", user);
++                let _ = std::fs::create_dir_all(&dir);
++                std::env::set_var("XDG_RUNTIME_DIR", &dir);
++            }
++        }
++    }
++    std::env::set_var("AT_SPI_BUS_ADDRESS", "/dev/null");
 +    std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
 +    std::env::set_var("WEBKIT_DISABLE_COMPOSITING_MODE", "1");
 +    std::env::set_var("WEBKIT_DISABLE_SANDBOX_THIS_IS_DANGEROUS", "1");
@@ -18,6 +50,6 @@ index 51d68ebd..a3f7c2d4 100644
 +    std::env::set_var("GDK_GL", "disable");
 +    std::env::set_var("LIBGL_ALWAYS_SOFTWARE", "1");
 +    std::env::set_var("GSK_RENDERER", "cairo");
-
+ 
      // Create shared client with cookie jar
      let state = Arc::new(AppState {

--- a/patches/apk/alpine.3.22.patch
+++ b/patches/apk/alpine.3.22.patch
@@ -1,16 +1,48 @@
 diff --git a/src-tauri/src/main.rs b/src-tauri/src/main.rs
-index 51d68ebd..1c6b3a11 100644
+index 51d68ebd..9fc477ca 100644
 --- a/src-tauri/src/main.rs
 +++ b/src-tauri/src/main.rs
-@@ -194,9 +194,15 @@ async fn proxy_request(
+@@ -194,9 +194,47 @@ async fn proxy_request(
  }
  
  fn main() {
 -    // NOTE: WebKitGTK env vars (GDK_GL, WEBKIT_DISABLE_*, etc.) are NOT set here.
 -    // They are distro-specific and belong in patches/<package>/<distro>.patch
 -    // and the package's AppRun/wrapper script. The base binary ships clean.
-+    // WebKitGTK environment for Alpine 3.22 APK builds.
-+    // Alpine is musl-based, so APK support must be built and tested separately.
++    // WebKitGTK environment for Alpine 3.22 (musl) APK builds.
++    // Alpine musl lacks systemd D-Bus auto-launching, so we must provide
++    // a working session bus or WebKitWebProcess will SIGABRT in
++    // g_dbus_address_get_stream_sync() when the inherited bus socket
++    // is inaccessible (e.g. owned by lightdm/root).
++    {
++        let bus = std::env::var("DBUS_SESSION_BUS_ADDRESS").unwrap_or_default();
++        let bus_accessible = bus.starts_with("unix:path=")
++            && std::path::Path::new(&bus["unix:path=".len()..]).exists();
++        if !bus_accessible {
++            if let Ok(output) = std::process::Command::new("dbus-launch")
++                .arg("--sh-syntax")
++                .output()
++            {
++                for line in String::from_utf8_lossy(&output.stdout).lines() {
++                    if line.starts_with("DBUS_SESSION_BUS_ADDRESS=") {
++                        let addr = line
++                            .trim_start_matches("DBUS_SESSION_BUS_ADDRESS=")
++                            .trim_matches('\'')
++                            .trim_end_matches(';');
++                        std::env::set_var("DBUS_SESSION_BUS_ADDRESS", addr);
++                    }
++                }
++            }
++        }
++        if std::env::var("XDG_RUNTIME_DIR").is_err() {
++            if let Ok(user) = std::env::var("USER") {
++                let dir = format!("/tmp/runtime-{}", user);
++                let _ = std::fs::create_dir_all(&dir);
++                std::env::set_var("XDG_RUNTIME_DIR", &dir);
++            }
++        }
++    }
++    std::env::set_var("AT_SPI_BUS_ADDRESS", "/dev/null");
 +    std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
 +    std::env::set_var("WEBKIT_DISABLE_COMPOSITING_MODE", "1");
 +    std::env::set_var("WEBKIT_DISABLE_SANDBOX_THIS_IS_DANGEROUS", "1");

--- a/patches/apk/alpine.3.23.patch
+++ b/patches/apk/alpine.3.23.patch
@@ -1,16 +1,48 @@
 diff --git a/src-tauri/src/main.rs b/src-tauri/src/main.rs
-index 51d68ebd..0d0b5e77 100644
+index 51d68ebd..9fc477ca 100644
 --- a/src-tauri/src/main.rs
 +++ b/src-tauri/src/main.rs
-@@ -194,9 +194,15 @@ async fn proxy_request(
+@@ -194,9 +194,47 @@ async fn proxy_request(
  }
  
  fn main() {
 -    // NOTE: WebKitGTK env vars (GDK_GL, WEBKIT_DISABLE_*, etc.) are NOT set here.
 -    // They are distro-specific and belong in patches/<package>/<distro>.patch
 -    // and the package's AppRun/wrapper script. The base binary ships clean.
-+    // WebKitGTK environment for Alpine 3.23 APK builds.
-+    // Alpine is musl-based, so APK support must be built and tested separately.
++    // WebKitGTK environment for Alpine 3.23 (musl) APK builds.
++    // Alpine musl lacks systemd D-Bus auto-launching, so we must provide
++    // a working session bus or WebKitWebProcess will SIGABRT in
++    // g_dbus_address_get_stream_sync() when the inherited bus socket
++    // is inaccessible (e.g. owned by lightdm/root).
++    {
++        let bus = std::env::var("DBUS_SESSION_BUS_ADDRESS").unwrap_or_default();
++        let bus_accessible = bus.starts_with("unix:path=")
++            && std::path::Path::new(&bus["unix:path=".len()..]).exists();
++        if !bus_accessible {
++            if let Ok(output) = std::process::Command::new("dbus-launch")
++                .arg("--sh-syntax")
++                .output()
++            {
++                for line in String::from_utf8_lossy(&output.stdout).lines() {
++                    if line.starts_with("DBUS_SESSION_BUS_ADDRESS=") {
++                        let addr = line
++                            .trim_start_matches("DBUS_SESSION_BUS_ADDRESS=")
++                            .trim_matches('\'')
++                            .trim_end_matches(';');
++                        std::env::set_var("DBUS_SESSION_BUS_ADDRESS", addr);
++                    }
++                }
++            }
++        }
++        if std::env::var("XDG_RUNTIME_DIR").is_err() {
++            if let Ok(user) = std::env::var("USER") {
++                let dir = format!("/tmp/runtime-{}", user);
++                let _ = std::fs::create_dir_all(&dir);
++                std::env::set_var("XDG_RUNTIME_DIR", &dir);
++            }
++        }
++    }
++    std::env::set_var("AT_SPI_BUS_ADDRESS", "/dev/null");
 +    std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
 +    std::env::set_var("WEBKIT_DISABLE_COMPOSITING_MODE", "1");
 +    std::env::set_var("WEBKIT_DISABLE_SANDBOX_THIS_IS_DANGEROUS", "1");


### PR DESCRIPTION
## Summary

Alpine 3.23 APK workflow, release integration, D-Bus/at-spi crash fix, and promotion to release-gated.

Refs #77
Closes #77

### Changes

**Workflow fixes** (`.github/workflows/`)
- Fixed `build-apk.alpine.3.23.yml` — regenerated from working 3.22 workflow with correct YAML indentation (PR #73 merge corrupted the `Build APK` step indentation in both 3.22 and 3.23)
- Fixed `build-apk.alpine.3.22.yml` — same indentation corruption from PR #73
- Added `git config --global --add safe.directory` step to 3.23 workflow
- Wired 3.23 into `release.yml`: expectedWorkflows, artifact download, file routing, downloads table, install docs

**D-Bus/at-spi crash fix** (`patches/apk/`)
- All three Alpine APK patches (`alpine.3.20.patch`, `alpine.3.22.patch`, `alpine.3.23.patch`) updated with:
  - Auto-launch D-Bus session via `dbus-launch` if inherited bus socket is inaccessible (fixes WebKitWebProcess SIGABRT in `g_dbus_address_get_stream_sync`)
  - Set `AT_SPI_BUS_ADDRESS=/dev/null` to prevent accessibility bus crash
  - Auto-create `XDG_RUNTIME_DIR` if missing
  - Existing WebKit/GDK env vars preserved

**Promotion** (`packaging/`, `docs/`)
- `compatibility-map.yml`: Alpine 3.23 promoted from `roadmap-patch-ready` to `release-gated` with runtime smoke pass evidence
- `docs/packaging.md`: Alpine 3.23 moved to release-gated table, Alpine 3.22 added, runtime settings updated
- `patches/README.md`: Alpine 3.23 moved to release-gated list
- `docs/release-checklist.md`: Added APK Alpine 3.23 workflow check
- `docs/new-build-checklist.md`: Added D-Bus/at-spi lesson learned

## Testing

- Alpine 3.23 APK built successfully in GitHub Actions (run 25989491939, 17m57s)
- Artifact downloaded and extracted on Alpine 3.23 host
- App launches, renders Proton Drive login page, connects to API servers
- No WebKitWebProcess SIGABRT
- Login flow functional