### PR TITLE
(#80) Prepare v1.4.3 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -414,14 +414,30 @@ jobs:
           Report issues at https://github.com/${{ github.repository }}/issues
           EOF
 
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v1
-        with:
-          tag_name: ${{ steps.version.outputs.version }}
-          body_path: RELEASE_NOTES.md
-          files: release/*
-          draft: false
-          prerelease: ${{ steps.version.outputs.prerelease == 'true' }}
-          generate_release_notes: false
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  - name: Delete stale release assets
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+    run: |
+      TAG="${{ steps.version.outputs.version }}"
+      EXISTING=$(gh release view "$TAG" --json assets --jq '.assets[].name' 2>/dev/null || echo "")
+      if [ -n "$EXISTING" ]; then
+        echo "Cleaning existing assets before upload..."
+        echo "$EXISTING" | while read -r name; do
+          [ -z "$name" ] && continue
+          echo "  Deleting $name"
+          gh release delete-asset "$TAG" "$name" --yes || true
+        done
+      fi
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  - name: Create GitHub Release
+    uses: softprops/action-gh-release@v1
+    with:
+      tag_name: ${{ steps.version.outputs.version }}
+      body_path: RELEASE_NOTES.md
+      files: release/*
+      draft: false
+      prerelease: ${{ steps.version.outputs.prerelease == 'true' }}
+      generate_release_notes: false
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/aur/PKGBUILD
+++ b/aur/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: DonnieDice <donniedice@proton.me>
 pkgname=proton-drive
-pkgver=1.4.1
+pkgver=1.4.3
 pkgrel=1
 pkgdesc="Unofficial Linux desktop client for Proton Drive, built with Tauri"
 arch=('x86_64')

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,11 +4,29 @@
 
 ### Changed
 
+- Moved CONTRIBUTING.md and LICENSE into docs/ directory.
+- Overhauled README.md: centered header with app icon, badges (latest,
+  downloads, license, issues in Proton purple), lean About/Features section,
+  documentation link table, and disclaimer at bottom. Removed verbose Install,
+  Supported Systems, Troubleshooting, Building from Source, and Distribution
+  Storefront Roadmap sections.
 - Updated CONTRIBUTING.md to document commit and PR title conventions that
   match `docs/CONTRIBUTING.md`.
 - Version metadata bumped to 1.4.3.
+- AUR PKGBUILD and CI build script versions synced to 1.4.3.
 
 ### Fixed
+
+- Release workflow now deletes stale release assets before uploading to
+  prevent duplicate artifacts from accumulating across re-runs.
+- Removed stale v1.4.0 and v1.4.1 RPM artifacts from the v1.4.2 release.
+- zypper retry loops in openSUSE Tumbleweed workflow: added `exit 1` after
+  max retries.
+- LICENSE typo: "Licases" to "Licenses" (line 21).
+- Added `text` language tags to bare fenced code blocks in
+  `.opencode/agent/protondrive-conventions.md`, `CONTRIBUTING.md`, and
+  `docs/CONTRIBUTING.md`.
+- Fixed commit example in `docs/CONTRIBUTING.md` to include `(#123)` prefix.
 
 - Workflow triggers: all 17 build/spec workflows now include `feature/**`,
   `fix/**`, and `chore/**` branch push triggers plus `pull_request` on `main`,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "protondrive-linux",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "protondrive-linux",
-      "version": "1.4.2",
+      "version": "1.4.3",
       "license": "AGPL-3.0",
       "devDependencies": {
         "@tauri-apps/cli": "^2.11.2"

--- a/scripts/ci/build-aur-package.sh
+++ b/scripts/ci/build-aur-package.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 AUR_TARGET="${1:-arch-native}"
-VERSION="${2:-1.4.2}"
+VERSION="${2:-1.4.3}"
 BINARY_PATH="${3:-src-tauri/target/release/proton-drive}"
 ICONS_DIR="${4:-src-tauri/icons}"
 REPO_ROOT="${5:-.}"


### PR DESCRIPTION
Issue: #75

## Changes

- Synced AUR PKGBUILD (1.4.1->1.4.3), build-aur-package.sh (1.4.2->1.4.3), package-lock.json (1.4.2->1.4.3)
- Release workflow: added step to delete stale release assets before upload, preventing duplicate artifacts from accumulating
- Updated CHANGELOG.md with all 1.4.3 changes
- Cleaned stale v1.4.0/v1.4.1 RPM artifacts from v1.4.2 release