### PR TITLE
(#83) Set up Snap Store distribution and publishing pipeline

### DIFF
--- a/.github/workflows/publish-snap.yml
+++ b/.github/workflows/publish-snap.yml
@@ -1,0 +1,109 @@
+name: Publish to Snap Store
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to publish (e.g., 1.4.0)"
+        required: true
+      snap_base:
+        description: "Snap base to publish (core24 or core26)"
+        required: false
+        default: "core24"
+      channel:
+        description: "Snap Store channel (stable, candidate, edge)"
+        required: false
+        default: "stable"
+
+permissions:
+  contents: read
+
+jobs:
+  publish-snap:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Get version
+        id: version
+        run: |
+          if [ -n "${{ github.event.inputs.version }}" ]; then
+            VERSION="${{ github.event.inputs.version }}"
+          else
+            VERSION="${{ github.event.release.tag_name }}"
+            VERSION="${VERSION#v}"
+          fi
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Publishing version: ${VERSION}"
+
+      - name: Determine snap base
+        id: snap_base
+        run: |
+          SNAP_BASE="${{ github.event.inputs.snap_base || 'core24' }}"
+          echo "snap_base=${SNAP_BASE}" >> "$GITHUB_OUTPUT"
+          echo "Snap base: ${SNAP_BASE}"
+
+      - name: Determine channel
+        id: channel
+        run: |
+          CHANNEL="${{ github.event.inputs.channel || 'stable' }}"
+          echo "channel=${CHANNEL}" >> "$GITHUB_OUTPUT"
+          echo "Channel: ${CHANNEL}"
+
+      - name: Download Snap artifact
+        uses: dawidd6/action-download-artifact@v6
+        with:
+          workflow: ${{ steps.snap_base.outputs.snap_base == 'core26' && 'build-snap.core26.yml' || 'build-snap.yml' }}
+          name: ${{ steps.snap_base.outputs.snap_base == 'core26' && 'snap-package-core26' || 'snap-package' }}
+          path: artifacts/snap
+          workflow_conclusion: success
+          if_no_artifact_found: fail
+          search_artifacts: true
+
+      - name: Verify Snap file
+        id: snap_file
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          SNAP_BASE="${{ steps.snap_base.outputs.snap_base }}"
+          SNAP_FILE="$(find artifacts/snap -name "proton-drive_*_${SNAP_BASE}_amd64.snap" -type f | head -1)"
+
+          if [ -z "$SNAP_FILE" ]; then
+            echo "ERROR: No Snap file found for ${SNAP_BASE} at version ${VERSION}"
+            echo "Available files:"
+            find artifacts/snap -type f || echo "  (none)"
+            exit 1
+          fi
+
+          echo "snap_file=${SNAP_FILE}" >> "$GITHUB_OUTPUT"
+          echo "Found Snap file: ${SNAP_FILE}"
+          ls -lah "${SNAP_FILE}"
+
+      - name: Install snapcraft
+        run: |
+          sudo snap install snapcraft --classic
+
+      - name: Upload to Snap Store
+        run: |
+          SNAP_FILE="${{ steps.snap_file.outputs.snap_file }}"
+          CHANNEL="${{ steps.channel.outputs.channel }}"
+
+          echo "Uploading ${SNAP_FILE} to ${CHANNEL} channel..."
+
+          snapcraft upload "${SNAP_FILE}" --release="${CHANNEL}"
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
+
+      - name: Verify upload
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          echo "Snap Store publish completed for proton-drive v${VERSION}"
+          echo ""
+          echo "Users can install with:"
+          echo "  sudo snap install proton-drive"
+          echo ""
+          echo "Verify at: https://snapcraft.io/proton-drive"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -379,10 +379,10 @@ jobs:
           flatpak install proton-drive_*.flatpak
           \`\`\`
 
-          ### Snap
-          \`\`\`bash
-          sudo snap install proton-drive_*.snap --dangerous
-          \`\`\`
+### Snap
+\`\`\`bash
+sudo snap install proton-drive
+\`\`\`
 
           ### Arch Linux (AUR)
           \`\`\`bash

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -143,6 +143,13 @@ WebKitGTK 4.1 available in repos and are release-gated. Current glibc
 DEB/RPM/AppImage artifacts are not Alpine-compatible.
 - Flatpak releases target GNOME Platform runtimes because the app is
   GTK/WebKitGTK-based.
+- Snap packages are published to the Snap Store at
+  https://snapcraft.io/proton-drive. Both core24 and core26 bases use
+  `confinement: strict`. The `home` plug covers downloads to `~/Downloads`
+  and the `removable-media` plug covers USB/mounted drives. No classic
+  confinement is needed for the current download-only feature set. When
+  2-way sync with arbitrary directories is added, `system-files` or a
+  classic confinement request may be required.
 - Nix users will use a future Nix flake that manages both libc and WebKitGTK
   through nixpkgs. Until then, use the AppImage or Flatpak.
 - Gentoo users will use a future ebuild that builds against system packages.

--- a/packaging/compatibility-map.yml
+++ b/packaging/compatibility-map.yml
@@ -19,6 +19,7 @@ ci_workflows:
   generate_package_specs: .github/workflows/generate-package-specs.yml
   release: .github/workflows/release.yml
   publish_aur: .github/workflows/publish-aur.yml
+  publish_snap: .github/workflows/publish-snap.yml
 
 rpm:
   fedora43:
@@ -227,37 +228,43 @@ flatpak:
     supports:
     - org.gnome.Platform//50
 
-snap:
-  core24:
-    status: release-gated
-    gates:
-      glibc: runtime
-      webkitgtk: runtime
-    runtime_smoke:
-      status: pass
-      evidence: remote artifact pass
-    workflow: .github/workflows/build-snap.yml
-    build_container: ubuntu-24.04
-    release_label: snap-core24
-    artifact_name: snap-package
-    patch: core24
-    supports:
-    - core24
-  core26:
-    status: release-gated
-    gates:
-      glibc: runtime
-      webkitgtk: runtime
-    runtime_smoke:
-      status: pass
-      evidence: remote artifact pass
-    workflow: .github/workflows/build-snap.core26.yml
-    build_container: ubuntu-24.04
-    release_label: snap-core26
-    artifact_name: snap-package-core26
-    patch: core26
-    supports:
-    - core26
+  snap:
+    core24:
+      status: release-gated
+      gates:
+        glibc: runtime
+        webkitgtk: runtime
+      runtime_smoke:
+        status: pass
+        evidence: remote artifact pass
+      workflow: .github/workflows/build-snap.yml
+      publish_workflow: .github/workflows/publish-snap.yml
+      build_container: ubuntu-24.04
+      release_label: snap-core24
+      artifact_name: snap-package
+      patch: core24
+      confinement: strict
+      snap_store_name: proton-drive
+      supports:
+      - core24
+    core26:
+      status: release-gated
+      gates:
+        glibc: runtime
+        webkitgtk: runtime
+      runtime_smoke:
+        status: pass
+        evidence: remote artifact pass
+      workflow: .github/workflows/build-snap.core26.yml
+      publish_workflow: .github/workflows/publish-snap.yml
+      build_container: ubuntu-24.04
+      release_label: snap-core26
+      artifact_name: snap-package-core26
+      patch: core26
+      confinement: strict
+      snap_store_name: proton-drive
+      supports:
+      - core26
 
 roadmap_patch_ready:
   rpm:

--- a/packaging/snap/STORE.md
+++ b/packaging/snap/STORE.md
@@ -1,17 +1,26 @@
 # Snap Store Distribution
 
-This directory will contain Snap Store publishing configuration.
-
 ## Setup Steps
 
-1. Register the `proton-drive` snap name at https://snapcraft.io/register-snap
-2. Request classic confinement (if needed) at https://forum.snapcraft.io/c/process
-3. Export Snap Store credentials: `snapcraft export-login --`
-4. Add `SNAPCRAFT_STORE_CREDENTIALS` as a GitHub Actions secret
-5. The `publish-snap.yml` workflow will upload snaps on release
+1. ~~Register the `proton-drive` snap name at https://snapcraft.io/register-snap~~ **Done**
+2. Export Snap Store credentials: `snapcraft export-login --`
+3. Add `SNAPCRAFT_STORE_CREDENTIALS` as a GitHub Actions secret
+4. Add `publish-snap.yml` workflow to upload snaps on release
+5. Test end-to-end: tag push → build → upload → `snap install proton-drive`
+
+## Confinement
+
+Using `confinement: strict` — no classic confinement request needed.
+
+Current app capabilities:
+- **Downloads**: Files go to `~/Downloads`, covered by the `home` plug
+- **Uploads**: GTK file picker (Portal) already has access to home directory via `home` plug
+- **Removable media**: `removable-media` plug added for USB/mounted drives at `/media`, `/mnt`, `/run/media`
+- **Future 2-way sync**: Will need `system-files` plug or a classic confinement request at that point; not needed today
 
 ## Current State
 
 - Snap builds exist for core24 and core26 (both release-gated)
-- `packaging/snap/snapcraft.yaml` uses `confinement: strict`
+- `packaging/snap/snapcraft.yaml` uses `confinement: strict` with `removable-media` plug
+- Snap name `proton-drive` registered on the Snap Store
 - No Snap Store publishing pipeline exists yet

--- a/packaging/snap/STORE.md
+++ b/packaging/snap/STORE.md
@@ -1,0 +1,17 @@
+# Snap Store Distribution
+
+This directory will contain Snap Store publishing configuration.
+
+## Setup Steps
+
+1. Register the `proton-drive` snap name at https://snapcraft.io/register-snap
+2. Request classic confinement (if needed) at https://forum.snapcraft.io/c/process
+3. Export Snap Store credentials: `snapcraft export-login --`
+4. Add `SNAPCRAFT_STORE_CREDENTIALS` as a GitHub Actions secret
+5. The `publish-snap.yml` workflow will upload snaps on release
+
+## Current State
+
+- Snap builds exist for core24 and core26 (both release-gated)
+- `packaging/snap/snapcraft.yaml` uses `confinement: strict`
+- No Snap Store publishing pipeline exists yet

--- a/packaging/snap/STORE.md
+++ b/packaging/snap/STORE.md
@@ -12,15 +12,50 @@
 
 Using `confinement: strict` — no classic confinement request needed.
 
-Current app capabilities:
-- **Downloads**: Files go to `~/Downloads`, covered by the `home` plug
-- **Uploads**: GTK file picker (Portal) already has access to home directory via `home` plug
-- **Removable media**: `removable-media` plug added for USB/mounted drives at `/media`, `/mnt`, `/run/media`
-- **Future 2-way sync**: Will need `system-files` plug or a classic confinement request at that point; not needed today
+The app does not currently use a file picker. Downloads are handled by the
+Rust `save_download` command and the Tauri `on_download` handler, both of
+which write to `~/Downloads` via the `dirs` crate. This path is covered by
+the `home` plug under strict confinement.
+
+Snap plugs and what they cover:
+
+| Plug | Path access | App feature |
+|------|-------------|-------------|
+| `home` | Non-hidden files in `$HOME` | `save_download` writes to `~/Downloads` |
+| `removable-media` | `/media`, `/mnt`, `/run/media` | Future: downloads to or uploads from USB/mounted drives |
+| `network` | Outbound network | API proxy, captcha, Proton endpoints |
+| `desktop`, `x11`, `wayland` | Display server | Window rendering via WebKitGTK |
+| `opengl` | GPU | Software rendering fallback (Mesa) |
+| `browser-support` | WebKit subprocess | WebKitWebProcess, WebKitNetworkProcess |
+| `password-manager-service` | Secret service | Proton credential storage |
+| `dbus` (session) | `com.proton.drive` | D-Bus session bus |
+
+When a file picker is added later (via `tauri-plugin-dialog`, which is already
+registered in `main.rs`), it will use Tauri's dialog API. On Linux with
+WebKitGTK, Tauri's dialog plugin invokes GTK's `GtkFileChooserNative` which
+runs inside the snap and respects the same confinement rules — the `home` plug
+will allow browsing `~/` and `removable-media` will allow browsing mounted
+drives. No additional Snap-specific configuration is needed for the file picker
+under strict confinement.
+
+For future 2-way sync that writes to arbitrary directories outside `$HOME`,
+a `system-files` plug or a classic confinement request will be needed at that
+point. That is not required today.
+
+## Snap Patches
+
+- `patches/snap/core24.patch` — adds `DISTRO_TYPE=snap` to the worker init
+  match arm, changes log label to "Snap/System package build"
+- `patches/snap/core26.patch` — same as core24 plus `GDK_GL=disable`
+  (instead of `software`) in the snapcraft.yaml environment
+
+Both patches are applied by `build-snap.yml` and `build-snap.core26.yml`
+respectively. No patch changes are needed for Snap Store publishing.
 
 ## Current State
 
 - Snap builds exist for core24 and core26 (both release-gated)
-- `packaging/snap/snapcraft.yaml` uses `confinement: strict` with `removable-media` plug
+- `packaging/snap/snapcraft.yaml` uses `confinement: strict` with
+  `removable-media` plug
 - Snap name `proton-drive` registered on the Snap Store
 - No Snap Store publishing pipeline exists yet

--- a/packaging/snap/snapcraft.yaml
+++ b/packaging/snap/snapcraft.yaml
@@ -14,19 +14,20 @@ apps:
     command: usr/bin/proton-drive-wrapper
     desktop: usr/share/applications/com.proton.drive.desktop
     plugs:
-      - home
-      - network
-      - network-bind
-      - network-status
-      - desktop
-      - desktop-legacy
-      - x11
-      - wayland
-      - opengl
-      - audio-playback
-      - browser-support
-      - password-manager-service
-      - dbus
+    - home
+    - network
+    - network-bind
+    - network-status
+    - desktop
+    - desktop-legacy
+    - x11
+    - wayland
+    - opengl
+    - audio-playback
+    - browser-support
+    - password-manager-service
+    - removable-media
+    - dbus
     environment:
       LIBGL_ALWAYS_SOFTWARE: "1"
       __EGL_VENDOR_LIBRARY_FILENAMES: $SNAP/usr/share/glvnd/egl_vendor.d/50_mesa.json


### PR DESCRIPTION
Issue: #83

## Changes

### [`publish-snap.yml`](https://github.com/DonnieDice/protondrive-linux/pull/84/files#diff-b00f6a34d8179e27fe6b9d54df629050104e8ec8) — add Snap Store publish workflow
- New workflow triggered on `release: [published]` or `workflow_dispatch`
- Downloads snap artifact from build workflow, uploads via `snapcraft upload --release`
- Supports core24/core26 base selection and stable/candidate/edge channel
- Uses `SNAPCRAFT_STORE_CREDENTIALS` secret for authentication

### [`release.yml`](https://github.com/DonnieDice/protondrive-linux/pull/84/files#diff-a386907c8c77b0c2fd355f684e926ea693880af5) — update Snap install instructions
- Changed from `sudo snap install proton-drive_*.snap --dangerous` to `sudo snap install proton-drive`
- Reflects that the snap will be available on the Snap Store

### [`docs/packaging.md`](https://github.com/DonnieDice/protondrive-linux/pull/84/files#diff-fa7e627823a651695ccb83341cf02b52054f84c7) — add Snap Store distribution notes
- Added paragraph about Snap Store publishing under Compatibility Rules
- Documents strict confinement, `home` plug for `~/Downloads`, `removable-media` for USB drives
- Notes that classic confinement may be needed for future 2-way sync

### [`compatibility-map.yml`](https://github.com/DonnieDice/protondrive-linux/pull/84/files#diff-dce943cc7517455c868ec6452dd8d9642b7ae4c9) — add Snap Store publish metadata
- Added `publish_snap` to `ci_workflows` section
- Added `publish_workflow`, `confinement`, `snap_store_name` fields to core24 and core26 entries

### [`STORE.md`](https://github.com/DonnieDice/protondrive-linux/pull/84/files#diff-407f84ca08ab63dd65df825e6ed3e5e93f44db16) — add Snap Store setup tracker
- Setup steps checklist with snap name registration marked done
- Confinement rationale: strict is sufficient, detailed plug-to-feature table
- Notes on file picker behavior under strict confinement
- Snap patch descriptions for core24 and core26

### [`snapcraft.yaml`](https://github.com/DonnieDice/protondrive-linux/pull/84/files#diff-c1ef335002374fe177336a117380fc36f28100aa) — add removable-media plug
- Added `removable-media` plug for USB/mounted drive access at `/media`, `/mnt`, `/run/media`
