### PR TITLE
(#89) Add Flathub publishing, fix Flatpak/Snap manifests

### DIFF
--- a/.github/workflows/build-flatpak.gnome49.yml
+++ b/.github/workflows/build-flatpak.gnome49.yml
@@ -107,15 +107,14 @@ jobs:
           flatpak remote-add --user --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
           flatpak install --user -y flathub org.gnome.Platform//49 org.gnome.Sdk//49 || true
 
-          cat > proton-drive-wrapper.sh << 'EOF'
-          #!/bin/bash
-          export WEBKIT_DISABLE_DMABUF_RENDERER=1
-          export WEBKIT_DISABLE_COMPOSITING_MODE=1
-          export WEBKIT_DISABLE_SANDBOX_THIS_IS_DANGEROUS=1
-          export GDK_GL=software
-          export GSK_RENDERER=cairo
-          exec /app/bin/proton-drive-bin "$@"
-          EOF
+      cat > proton-drive-wrapper.sh << 'EOF'
+      #!/bin/bash
+      export WEBKIT_DISABLE_DMABUF_RENDERER=1
+      export WEBKIT_DISABLE_COMPOSITING_MODE=1
+      export WEBKIT_DISABLE_SANDBOX_THIS_IS_DANGEROUS=1
+      export GDK_GL=software
+      exec /app/bin/proton-drive-bin "$@"
+      EOF
           chmod +x proton-drive-wrapper.sh
 
           cat > com.proton.drive.desktop << 'EOF'
@@ -138,6 +137,7 @@ jobs:
           cp src-tauri/icons/128x128@2x.png flatpak-staging/icons/
           cp src-tauri/icons/proton-drive.svg flatpak-staging/icons/
           cp com.proton.drive.desktop flatpak-staging/
+cp packaging/com.proton.drive.metainfo.xml flatpak-staging/
 
           cat > com.proton.drive.yml << YAMLEOF
           app-id: com.proton.drive
@@ -145,18 +145,17 @@ jobs:
           runtime-version: '49'
           sdk: org.gnome.Sdk
           command: proton-drive
-          finish-args:
-            - --share=network
-            - --share=ipc
-            - --socket=x11
-            - --socket=wayland
-            - --socket=pulseaudio
-            - --device=dri
-            - --filesystem=home
-            - --filesystem=xdg-download
-            - --talk-name=org.freedesktop.secrets
-            - --talk-name=org.freedesktop.Notifications
-            - --system-talk-name=org.freedesktop.NetworkManager
+      finish-args:
+      - --share=network
+      - --share=ipc
+      - --socket=fallback-x11
+      - --socket=wayland
+      - --socket=pulseaudio
+      - --device=dri
+      - --filesystem=xdg-download
+      - --filesystem=xdg-documents
+      - --talk-name=org.freedesktop.secrets
+      - --talk-name=org.freedesktop.Notifications
           modules:
             - name: proton-drive
               buildsystem: simple
@@ -170,8 +169,9 @@ jobs:
                 - install -Dm644 icons/128x128.png /app/share/icons/hicolor/128x128/apps/com.proton.drive.png
                 - install -Dm644 icons/128x128@2x.png /app/share/icons/hicolor/256x256/apps/com.proton.drive.png
                 - install -Dm644 icons/proton-drive.svg /app/share/icons/hicolor/scalable/apps/com.proton.drive.svg
-                - install -Dm644 com.proton.drive.desktop /app/share/applications/com.proton.drive.desktop
-          YAMLEOF
+      - install -Dm644 com.proton.drive.desktop /app/share/applications/com.proton.drive.desktop
+      - install -Dm644 com.proton.drive.metainfo.xml /app/share/metainfo/com.proton.drive.metainfo.xml
+YAMLEOF
           sed -i 's/^          //' com.proton.drive.yml
 
           rm -rf build-dir repo

--- a/.github/workflows/build-flatpak.yml
+++ b/.github/workflows/build-flatpak.yml
@@ -107,15 +107,15 @@ jobs:
           flatpak remote-add --user --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
           flatpak install --user -y flathub org.gnome.Platform//50 org.gnome.Sdk//50 || true
 
-          cat > proton-drive-wrapper.sh << 'EOF'
-          #!/bin/bash
-          export WEBKIT_DISABLE_DMABUF_RENDERER=1
-          export WEBKIT_DISABLE_COMPOSITING_MODE=1
-          export WEBKIT_DISABLE_SANDBOX_THIS_IS_DANGEROUS=1
-          export GDK_GL=software
-          export GSK_RENDERER=cairo
-          exec /app/bin/proton-drive-bin "$@"
-          EOF
+cat > proton-drive-wrapper.sh << 'EOF'
+#!/bin/bash
+export WEBKIT_DISABLE_DMABUF_RENDERER=1
+export WEBKIT_DISABLE_COMPOSITING_MODE=1
+export WEBKIT_DISABLE_SANDBOX_THIS_IS_DANGEROUS=1
+export GDK_GL=disable
+export GSK_RENDERER=cairo
+exec /app/bin/proton-drive-bin "$@"
+EOF
           chmod +x proton-drive-wrapper.sh
 
           cat > com.proton.drive.desktop << 'EOF'
@@ -138,6 +138,7 @@ jobs:
           cp src-tauri/icons/128x128@2x.png flatpak-staging/icons/
           cp src-tauri/icons/proton-drive.svg flatpak-staging/icons/
           cp com.proton.drive.desktop flatpak-staging/
+cp packaging/com.proton.drive.metainfo.xml flatpak-staging/
 
           cat > com.proton.drive.yml << YAMLEOF
           app-id: com.proton.drive
@@ -145,18 +146,17 @@ jobs:
           runtime-version: '50'
           sdk: org.gnome.Sdk
           command: proton-drive
-          finish-args:
-            - --share=network
-            - --share=ipc
-            - --socket=x11
-            - --socket=wayland
-            - --socket=pulseaudio
-            - --device=dri
-            - --filesystem=home
-            - --filesystem=xdg-download
-            - --talk-name=org.freedesktop.secrets
-            - --talk-name=org.freedesktop.Notifications
-            - --system-talk-name=org.freedesktop.NetworkManager
+      finish-args:
+      - --share=network
+      - --share=ipc
+      - --socket=fallback-x11
+      - --socket=wayland
+      - --socket=pulseaudio
+      - --device=dri
+      - --filesystem=xdg-download
+      - --filesystem=xdg-documents
+      - --talk-name=org.freedesktop.secrets
+      - --talk-name=org.freedesktop.Notifications
           modules:
             - name: proton-drive
               buildsystem: simple
@@ -169,8 +169,9 @@ jobs:
                 - install -Dm644 icons/32x32.png /app/share/icons/hicolor/32x32/apps/com.proton.drive.png
                 - install -Dm644 icons/128x128.png /app/share/icons/hicolor/128x128/apps/com.proton.drive.png
                 - install -Dm644 icons/128x128@2x.png /app/share/icons/hicolor/256x256/apps/com.proton.drive.png
-                - install -Dm644 icons/proton-drive.svg /app/share/icons/hicolor/scalable/apps/com.proton.drive.svg
-                - install -Dm644 com.proton.drive.desktop /app/share/applications/com.proton.drive.desktop
+      - install -Dm644 icons/proton-drive.svg /app/share/icons/hicolor/scalable/apps/com.proton.drive.svg
+      - install -Dm644 com.proton.drive.desktop /app/share/applications/com.proton.drive.desktop
+      - install -Dm644 com.proton.drive.metainfo.xml /app/share/metainfo/com.proton.drive.metainfo.xml
           YAMLEOF
           sed -i 's/^          //' com.proton.drive.yml
 

--- a/.github/workflows/publish-flatpak.yml
+++ b/.github/workflows/publish-flatpak.yml
@@ -1,0 +1,205 @@
+name: Publish to Flathub
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to publish (e.g., 1.4.0)"
+        required: true
+      runtime:
+        description: "GNOME runtime version (49 or 50)"
+        required: false
+        default: "50"
+
+permissions:
+  contents: read
+
+jobs:
+  publish-flathub:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Get version
+        id: version
+        run: |
+          if [ -n "${{ github.event.inputs.version }}" ]; then
+            VERSION="${{ github.event.inputs.version }}"
+          else
+            VERSION="${{ github.event.release.tag_name }}"
+            VERSION="${VERSION#v}"
+          fi
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Publishing version: ${VERSION}"
+
+      - name: Determine runtime
+        id: runtime
+        run: |
+          RUNTIME="${{ github.event.inputs.runtime || '50' }}"
+          echo "runtime=${RUNTIME}" >> "$GITHUB_OUTPUT"
+          echo "GNOME runtime: ${RUNTIME}"
+
+      - name: Resolve WebClients commit
+        id: webclients
+        run: |
+          WEBCLIENTS_REF="main"
+          COMMIT_SHA=$(curl -sL -H "Accept: application/vnd.github.v3+json" \
+            "https://api.github.com/repos/ProtonMail/WebClients/commits/${WEBCLIENTS_REF}" \
+            | python3 -c "import sys,json; print(json.load(sys.stdin)['sha'])")
+          echo "commit=${COMMIT_SHA}" >> "$GITHUB_OUTPUT"
+          echo "WebClients commit: ${COMMIT_SHA}"
+
+      - name: Get source commit SHA
+        id: source
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          COMMIT_SHA=$(git ls-remote https://github.com/${{ github.repository }}.git "refs/tags/v${VERSION}" | cut -f1)
+          if [ -z "$COMMIT_SHA" ]; then
+            echo "ERROR: Tag v${VERSION} not found in remote"
+            exit 1
+          fi
+          echo "commit=${COMMIT_SHA}" >> "$GITHUB_OUTPUT"
+          echo "Source commit: ${COMMIT_SHA}"
+
+      - name: Calculate WebClients tarball checksum
+        id: webclients_sha
+        run: |
+          WEBCCLIENTS_COMMIT="${{ steps.webclients.outputs.commit }}"
+          curl -sL "https://github.com/ProtonMail/WebClients/archive/${WEBCCLIENTS_COMMIT}.tar.gz" -o webclients.tar.gz
+          WEBCCLIENTS_SHA256=$(sha256sum webclients.tar.gz | cut -d' ' -f1)
+          echo "sha256=${WEBCCLIENTS_SHA256}" >> "$GITHUB_OUTPUT"
+          echo "WebClients SHA256: ${WEBCCLIENTS_SHA256}"
+          rm webclients.tar.gz
+
+      - name: Setup SSH for Flathub
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.FLATHUB_SSH_PRIVATE_KEY }}" > ~/.ssh/flathub
+          chmod 600 ~/.ssh/flathub
+
+          cat >> ~/.ssh/config << EOF
+          Host github.com
+            IdentityFile ~/.ssh/flathub
+            User git
+            StrictHostKeyChecking no
+          EOF
+
+      - name: Clone Flathub repo
+        run: |
+          git clone git@github.com:flathub/com.proton.drive.git flathub-repo || \
+            { echo "ERROR: Flathub repo flathub/com.proton.drive not found."; \
+              echo "Initial Flathub submission is required first via PR to flathub/flathub."; \
+              echo "See https://docs.flathub.org/docs/for-app-authors/submission"; \
+              exit 1; }
+
+          cd flathub-repo
+          git config user.name "DonnieDice"
+          git config user.email "donniedice@proton.me"
+
+      - name: Update Flathub manifest
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          RUNTIME="${{ steps.runtime.outputs.runtime }}"
+          SOURCE_COMMIT="${{ steps.source.outputs.commit }}"
+          WEBCCLIENTS_SHA256="${{ steps.webclients_sha.outputs.sha256 }}"
+          WEBCCLIENTS_COMMIT="${{ steps.webclients.outputs.commit }}"
+
+          cd flathub-repo
+
+          cat > com.proton.drive.yml << YAMLEOF
+          app-id: com.proton.drive
+          runtime: org.gnome.Platform
+          runtime-version: "${RUNTIME}"
+          sdk: org.gnome.Sdk
+          sdk-extensions:
+            - org.freedesktop.Sdk.Extension.node22
+            - org.freedesktop.Sdk.Extension.rust-stable
+          command: proton-drive
+          finish-args:
+            - --share=network
+            - --share=ipc
+            - --socket=fallback-x11
+            - --socket=wayland
+            - --socket=pulseaudio
+            - --device=dri
+            - --filesystem=xdg-download
+            - --filesystem=xdg-documents
+            - --talk-name=org.freedesktop.secrets
+            - --talk-name=org.freedesktop.Notifications
+          modules:
+            - name: proton-drive
+              buildsystem: simple
+              sources:
+                - type: git
+                  url: https://github.com/DonnieDice/protondrive-linux.git
+                  tag: v${VERSION}
+                  commit: ${SOURCE_COMMIT}
+                - type: archive
+                  url: https://github.com/ProtonMail/WebClients/archive/${WEBCCLIENTS_COMMIT}.tar.gz
+                  sha256: ${WEBCCLIENTS_SHA256}
+                  dest: WebClients
+              build-commands:
+                - . /usr/lib/sdk/node22/enable.sh
+                - . /usr/lib/sdk/rust-stable/enable.sh
+                - rm -rf WebClients && ln -sf "WebClients-${WEBCCLIENTS_COMMIT}" WebClients
+                - ./scripts/build-webclients.sh
+                - npm install
+                - cd src-tauri && cargo build --release && cd ..
+                - install -Dm755 src-tauri/target/release/proton-drive /app/bin/proton-drive-bin
+                - |
+                  cat > /app/bin/proton-drive << 'WEOF'
+                  #!/bin/bash
+                  export WEBKIT_DISABLE_DMABUF_RENDERER=1
+                  export WEBKIT_DISABLE_COMPOSITING_MODE=1
+                  export WEBKIT_DISABLE_SANDBOX_THIS_IS_DANGEROUS=1
+                  export GDK_GL=disable
+                  exec /app/bin/proton-drive-bin "\$@"
+                  WEOF
+                  chmod +x /app/bin/proton-drive
+                - install -Dm644 src-tauri/linux/proton-drive.desktop /app/share/applications/com.proton.drive.desktop
+                - sed -i 's/Icon=proton-drive/Icon=com.proton.drive/' /app/share/applications/com.proton.drive.desktop
+                - install -Dm644 packaging/com.proton.drive.metainfo.xml /app/share/metainfo/com.proton.drive.metainfo.xml
+                - install -Dm644 src-tauri/icons/32x32.png /app/share/icons/hicolor/32x32/apps/com.proton.drive.png
+                - install -Dm644 src-tauri/icons/128x128.png /app/share/icons/hicolor/128x128/apps/com.proton.drive.png
+                - install -Dm644 src-tauri/icons/128x128@2x.png /app/share/icons/hicolor/256x256/apps/com.proton.drive.png
+                - install -Dm644 src-tauri/icons/proton-drive.svg /app/share/icons/hicolor/scalable/apps/com.proton.drive.svg
+          YAMLEOF
+
+          sed -i 's/^          //' com.proton.drive.yml
+
+          echo "Updated manifest:"
+          cat com.proton.drive.yml
+
+      - name: Update metainfo release
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          RELEASE_DATE=$(date -u +'%Y-%m-%d')
+
+          cd flathub-repo
+
+          if [ -f com.proton.drive.metainfo.xml ]; then
+            if grep -q "version=\"${VERSION}\"" com.proton.drive.metainfo.xml; then
+              echo "Release ${VERSION} already in metainfo, skipping"
+            else
+              sed -i "/<releases>/a\\  <release version=\"${VERSION}\" date=\"${RELEASE_DATE}\" />" com.proton.drive.metainfo.xml
+            fi
+          else
+            cp ../packaging/com.proton.drive.metainfo.xml .
+          fi
+
+      - name: Commit and push to Flathub
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          cd flathub-repo
+          git add -A
+          git commit -m "Update to v${VERSION}" || echo "No changes to commit"
+          git push origin master
+
+      - name: Cleanup
+        if: always()
+        run: rm -rf ~/.ssh/flathub flathub-repo

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -349,8 +349,8 @@ jobs:
           | Format | File | Description |
           |--------|------|-------------|
           | AppImage | \`proton-drive_*.AppImage\` | Universal Linux (portable, glibc 2.35+) |
-          | Flatpak (GNOME 50) | \`proton-drive_*_gnome50.flatpak\` | Flatpak sandbox (org.gnome.Platform//50) |
-          | Flatpak (GNOME 49) | \`proton-drive_*_gnome49.flatpak\` | Flatpak sandbox (org.gnome.Platform//49) |
+| Flatpak (GNOME 50) | \`proton-drive_*_gnome50.flatpak\` | Flatpak sandbox (org.gnome.Platform//50), also on Flathub |
+| Flatpak (GNOME 49) | \`proton-drive_*_gnome49.flatpak\` | Flatpak sandbox (org.gnome.Platform//49), also on Flathub |
           | Snap (core24) | \`proton-drive_*_core24_amd64.snap\` | Snap package (core24 runtime) |
           | Snap (core26) | \`proton-drive_*_core26_amd64.snap\` | Snap package (core26 runtime) |
           | AUR | \`proton-drive-*.pkg.tar.zst\` | Arch Linux / Manjaro / EndeavourOS / Garuda |
@@ -374,10 +374,15 @@ jobs:
           ./proton-drive_*.AppImage
           \`\`\`
 
-          ### Flatpak
-          \`\`\`bash
-          flatpak install proton-drive_*.flatpak
-          \`\`\`
+### Flatpak
+\`\`\`bash
+flatpak install flathub com.proton.drive
+\`\`\`
+
+Or install the standalone bundle:
+\`\`\`bash
+flatpak install proton-drive_*.flatpak
+\`\`\`
 
 ### Snap
 \`\`\`bash

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -134,7 +134,11 @@ described above. Both must pass for a target to be `release-gated`.
 - Linux Mint, Pop!_OS, Zorin, and similar Ubuntu derivatives use the Ubuntu DEB
   that matches their Ubuntu base.
 - Arch derivatives use the AUR target or AppImage.
-- The AUR package is a native build that compiles against Arch system packages. It replaced the former AppImage-wrapper package (`proton-drive-bin`) in v1.4.0.
+- The AUR package is a native build that compiles against Arch system
+  packages. It replaced the former AppImage-wrapper package
+  (`proton-drive-bin`) in v1.4.0. The AUR package is published via
+  `publish-aur.yml`, which pushes PKGBUILD and .SRCINFO to
+  `aur.archlinux.org/proton-drive` on release.
 - RHEL 10, CentOS Stream 10, AlmaLinux 10, and Rocky Linux 10 share the EL10 RPM
   line.
 - openSUSE Tumbleweed users use the Tumbleweed RPM. Leap 16 users should use AppImage until a Leap 16 RPM workflow and smoke test are added.
@@ -142,9 +146,14 @@ described above. Both must pass for a target to be `release-gated`.
 WebKitGTK 4.1 available in repos and are release-gated. Current glibc
 DEB/RPM/AppImage artifacts are not Alpine-compatible.
 - Flatpak releases target GNOME Platform runtimes because the app is
-  GTK/WebKitGTK-based.
+  GTK/WebKitGTK-based. Flatpak packages are published to Flathub at
+  https://flathub.org/apps/com.proton.drive via the `publish-flatpak.yml`
+  workflow. An initial Flathub submission PR to `flathub/flathub` is required
+  before the publish workflow can push updates. The reference source-build
+  manifest is at `packaging/com.proton.drive.yml`.
 - Snap packages are published to the Snap Store at
-  https://snapcraft.io/proton-drive. Both core24 and core26 bases use
+  https://snapcraft.io/proton-drive via the `publish-snap.yml`
+  workflow. Both core24 and core26 bases use
   `confinement: strict`. The `home` plug covers downloads to `~/Downloads`
   and the `removable-media` plug covers USB/mounted drives. No classic
   confinement is needed for the current download-only feature set. When
@@ -250,6 +259,8 @@ tag from `main`.
 Release checklist:
 
 - `main` has passing RPM, DEB, AppImage, Flatpak, Snap, and AUR workflows.
+- Publish workflows (`publish-aur.yml`, `publish-snap.yml`,
+  `publish-flatpak.yml`) have their required secrets configured.
 - Roadmap patch-ready targets are intentionally excluded from `release.yml`
   unless they completed the promotion checklist.
 - Runtime smoke records are updated in this file and
@@ -327,6 +338,21 @@ into:
 - `src-tauri/tauri.conf.json`
 - `src-tauri/Cargo.toml`
 - `aur/PKGBUILD`
+
+## Publishing Workflows
+
+Three publish workflows push packages to their respective stores on release:
+
+| Store | Workflow | Secret required | Target |
+|-------|----------|-----------------|--------|
+| AUR | `publish-aur.yml` | `AUR_SSH_PRIVATE_KEY` | `aur.archlinux.org/proton-drive` |
+| Snap Store | `publish-snap.yml` | `SNAPCRAFT_STORE_CREDENTIALS` | `snapcraft.io/proton-drive` |
+| Flathub | `publish-flatpak.yml` | `FLATHUB_SSH_PRIVATE_KEY` | `flathub/com.proton.drive` |
+
+All three workflows trigger on release publication or manual workflow dispatch.
+The Flathub workflow requires an initial submission PR to `flathub/flathub`
+before it can push updates (see
+https://docs.flathub.org/docs/for-app-authors/submission).
 
 ## Upstream Baseline Check
 

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -40,6 +40,11 @@ Use this checklist before every release deployment.
 - [ ] APK Alpine 3.22 workflow is passing.
 - [ ] APK Alpine 3.23 workflow is passing.
 - [ ] Release workflow is passing.
+- [ ] Publish workflow secrets are configured.
+- [ ] `AUR_SSH_PRIVATE_KEY` secret is set for AUR publishing.
+- [ ] `SNAPCRAFT_STORE_CREDENTIALS` secret is set for Snap Store publishing.
+- [ ] `FLATHUB_SSH_PRIVATE_KEY` secret is set for Flathub publishing.
+- [ ] Flathub initial submission PR has been merged (required before `publish-flatpak.yml` can push updates).
 
 - [ ] Merge approved PRs into `main`.
   - [ ] Confirm the PRs contain only commits intended for the release.

--- a/packaging/FLATHUB.md
+++ b/packaging/FLATHUB.md
@@ -1,0 +1,80 @@
+# Flathub Distribution
+
+## Setup Steps
+
+1. ~~Prepare the Flathub-ready manifest (`packaging/com.proton.drive.yml`)~~ **Done**
+2. ~~Prepare the AppStream metainfo (`packaging/com.proton.drive.metainfo.xml`)~~ **Done**
+3. Build and test the Flatpak locally:
+   ```bash
+   flatpak install -y flathub org.flatpak.Builder
+   flatpak remote-add --if-not-exists --user flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+   flatpak run --command=flathub-build org.flatpak.Builder --install packaging/com.proton.drive.yml
+   flatpak run com.proton.drive
+   ```
+4. Run the linter:
+   ```bash
+   flatpak run --command=flatpak-builder-lint org.flatpak.Builder manifest packaging/com.proton.drive.yml
+   ```
+5. Fork `flathub/flathub` on GitHub (copy the master branch only: unchecked)
+6. Create a submission branch from `new-pr`:
+   ```bash
+   git clone --branch=new-pr git@github.com:YOUR_GITHUB_USERNAME/flathub.git && cd flathub
+   git checkout -b proton-drive-submission new-pr
+   ```
+7. Add the manifest, metainfo, and desktop file, then push and open a PR
+   against the `new-pr` base branch. Title: "Add com.proton.drive"
+8. Address reviewer feedback, then request a test build with `bot, build`
+9. After approval, the repo will be created at `flathub/com.proton.drive`
+10. Accept the write access invitation (enable 2FA on GitHub first)
+11. Add `FLATHUB_SSH_PRIVATE_KEY` as a GitHub Actions secret in the
+    protondrive-linux repo
+12. The `publish-flatpak.yml` workflow will then push updates to the
+    Flathub repo on each release
+
+## Flathub Requirements
+
+- App ID: `com.proton.drive` (follows reverse-DNS convention)
+- License: AGPL-3.0 (approved by Flathub)
+- Source-build manifest (not a binary download) — `packaging/com.proton.drive.yml`
+  builds from the Git source with SDK extensions for Node.js and Rust
+- AppStream metainfo with screenshots, description, and release history
+- Desktop entry file with correct Icon ID (`com.proton.drive`)
+
+## finish-args Rationale
+
+| Permission | Reason |
+|-----------|--------|
+| `--share=network` | API proxy, captcha, Proton endpoints |
+| `--share=ipc` | X11 shared memory |
+| `--socket=fallback-x11` | X11 display (fallback, Wayland preferred) |
+| `--socket=wayland` | Wayland display |
+| `--socket=pulseaudio` | Audio playback for notifications |
+| `--device=dri` | GPU rendering |
+| `--filesystem=xdg-download` | Save downloaded files |
+| `--filesystem=xdg-documents` | Future file sync access |
+| `--talk-name=org.freedesktop.secrets` | Proton credential storage |
+| `--talk-name=org.freedesktop.Notifications` | Desktop notifications |
+
+## Runtime Settings
+
+The Flatpak wrapper sets these environment variables:
+
+- `WEBKIT_DISABLE_DMABUF_RENDERER=1` — avoid DMABUF rendering issues
+- `WEBKIT_DISABLE_COMPOSITING_MODE=1` — disable GPU compositing
+- `WEBKIT_DISABLE_SANDBOX_THIS_IS_DANGEROUS=1` — disable WebKit subprocess
+  sandbox (required for Flatpak WebKitGTK)
+- `GDK_GL=disable` (GNOME 50) or `GDK_GL=software` (GNOME 49) — GL rendering
+  mode
+- `GSK_RENDERER=cairo` — use Cairo for rendering
+
+## Current State
+
+- Flatpak builds exist for GNOME 49 and GNOME 50 (both release-gated)
+- Reference source-build manifest: `packaging/com.proton.drive.yml`
+- CI build manifests (pre-built binary approach) in `build-flatpak.yml` and
+  `build-flatpak.gnome49.yml`
+- Flathub publishing pipeline: `publish-flatpak.yml` pushes manifest updates
+  to `flathub/com.proton.drive` on release using `FLATHUB_SSH_PRIVATE_KEY`
+  secret
+- Initial Flathub submission PR is required before the publish workflow can
+  push updates

--- a/packaging/com.proton.drive.yml
+++ b/packaging/com.proton.drive.yml
@@ -3,58 +3,53 @@ runtime: org.gnome.Platform
 runtime-version: "50"
 sdk: org.gnome.Sdk
 sdk-extensions:
-  - org.freedesktop.Sdk.Extension.node22
-  - org.freedesktop.Sdk.Extension.rust-stable
+- org.freedesktop.Sdk.Extension.node22
+- org.freedesktop.Sdk.Extension.rust-stable
 command: proton-drive
 finish-args:
-  - --share=network
-  - --share=ipc
-  - --socket=fallback-x11
-  - --socket=wayland
-  - --socket=pulseaudio
-  - --device=dri
-  - --filesystem=xdg-download
-  - --filesystem=xdg-documents
-  - --talk-name=org.freedesktop.secrets
-  - --talk-name=org.freedesktop.Notifications
+- --share=network
+- --share=ipc
+- --socket=fallback-x11
+- --socket=wayland
+- --socket=pulseaudio
+- --device=dri
+- --filesystem=xdg-download
+- --filesystem=xdg-documents
+- --talk-name=org.freedesktop.secrets
+- --talk-name=org.freedesktop.Notifications
 modules:
-  - name: proton-drive
-    buildsystem: simple
-    sources:
-      - type: git
-        url: https://github.com/DonnieDice/protondrive-linux.git
-        commit: 469793bf6038ebecf2b7c23d6236d450b8a6a5c4
-      - type: file
-        path: packaging/com.proton.drive.metainfo.xml
-    build-commands:
-      # Enable SDK extensions
-      - . /usr/lib/sdk/node22/enable.sh
-      - . /usr/lib/sdk/rust-stable/enable.sh
-
-      # Build the application
-      - ./scripts/build-webclients.sh
-      - npm install
-      - cd src-tauri && cargo build --release
-
-      # Install binary and wrapper
-      - install -Dm755 src-tauri/target/release/proton-drive /app/bin/proton-drive-bin
-      - |
-        cat > /app/bin/proton-drive << 'EOF'
-        #!/bin/bash
-        export WEBKIT_DISABLE_DMABUF_RENDERER=1
-        exec /app/bin/proton-drive-bin "$@"
-        EOF
-        chmod +x /app/bin/proton-drive
-
-      # Install desktop file
-      - install -Dm644 src-tauri/linux/proton-drive.desktop /app/share/applications/com.proton.drive.desktop
-      - sed -i 's/Icon=proton-drive/Icon=com.proton.drive/' /app/share/applications/com.proton.drive.desktop
-
-      # Install AppStream metadata
-      - install -Dm644 packaging/com.proton.drive.metainfo.xml /app/share/metainfo/com.proton.drive.metainfo.xml
-
-      # Install icons
-      - install -Dm644 src-tauri/icons/32x32.png /app/share/icons/hicolor/32x32/apps/com.proton.drive.png
-      - install -Dm644 src-tauri/icons/128x128.png /app/share/icons/hicolor/128x128/apps/com.proton.drive.png
-      - install -Dm644 src-tauri/icons/128x128@2x.png /app/share/icons/hicolor/256x256/apps/com.proton.drive.png
-      - install -Dm644 src-tauri/icons/proton-drive.svg /app/share/icons/hicolor/scalable/apps/com.proton.drive.svg
+- name: proton-drive
+  buildsystem: simple
+  sources:
+  - type: git
+    url: https://github.com/DonnieDice/protondrive-linux.git
+    commit: PLACEHOLDER
+  - type: archive
+    url: https://github.com/ProtonMail/WebClients/archive/PLACEHOLDER_COMMIT.tar.gz
+    sha256: PLACEHOLDER_SHA256
+    dest: WebClients
+  build-commands:
+  - . /usr/lib/sdk/node22/enable.sh
+  - . /usr/lib/sdk/rust-stable/enable.sh
+  - rm -rf WebClients && ln -sf "WebClients-PLACEHOLDER_COMMIT" WebClients
+  - ./scripts/build-webclients.sh
+  - npm install
+  - cd src-tauri && cargo build --release && cd ..
+  - install -Dm755 src-tauri/target/release/proton-drive /app/bin/proton-drive-bin
+  - |
+    cat > /app/bin/proton-drive << 'EOF'
+    #!/bin/bash
+    export WEBKIT_DISABLE_DMABUF_RENDERER=1
+    export WEBKIT_DISABLE_COMPOSITING_MODE=1
+    export WEBKIT_DISABLE_SANDBOX_THIS_IS_DANGEROUS=1
+    export GDK_GL=disable
+    exec /app/bin/proton-drive-bin "$@"
+    EOF
+    chmod +x /app/bin/proton-drive
+  - install -Dm644 src-tauri/linux/proton-drive.desktop /app/share/applications/com.proton.drive.desktop
+  - sed -i 's/Icon=proton-drive/Icon=com.proton.drive/' /app/share/applications/com.proton.drive.desktop
+  - install -Dm644 packaging/com.proton.drive.metainfo.xml /app/share/metainfo/com.proton.drive.metainfo.xml
+  - install -Dm644 src-tauri/icons/32x32.png /app/share/icons/hicolor/32x32/apps/com.proton.drive.png
+  - install -Dm644 src-tauri/icons/128x128.png /app/share/icons/hicolor/128x128/apps/com.proton.drive.png
+  - install -Dm644 src-tauri/icons/128x128@2x.png /app/share/icons/hicolor/256x256/apps/com.proton.drive.png
+  - install -Dm644 src-tauri/icons/proton-drive.svg /app/share/icons/hicolor/scalable/apps/com.proton.drive.svg

--- a/packaging/compatibility-map.yml
+++ b/packaging/compatibility-map.yml
@@ -20,6 +20,7 @@ ci_workflows:
   release: .github/workflows/release.yml
   publish_aur: .github/workflows/publish-aur.yml
   publish_snap: .github/workflows/publish-snap.yml
+  publish_flatpak: .github/workflows/publish-flatpak.yml
 
 rpm:
   fedora43:
@@ -206,10 +207,12 @@ flatpak:
       status: pass
       evidence: remote artifact pass
     workflow: .github/workflows/build-flatpak.gnome49.yml
+    publish_workflow: .github/workflows/publish-flatpak.yml
     build_container: ubuntu-24.04
     release_label: flatpak-gnome49
     artifact_name: flatpak-package-gnome49
     patch: org.gnome.Platform.49
+    flathub_app_id: com.proton.drive
     supports:
     - org.gnome.Platform//49
   org.gnome.Platform.50:
@@ -221,10 +224,12 @@ flatpak:
       status: pass
       evidence: remote artifact pass
     workflow: .github/workflows/build-flatpak.yml
+    publish_workflow: .github/workflows/publish-flatpak.yml
     build_container: ubuntu-24.04
     release_label: flatpak-gnome50
     artifact_name: flatpak-package
     patch: org.gnome.Platform.50
+    flathub_app_id: com.proton.drive
     supports:
     - org.gnome.Platform//50
 

--- a/packaging/snap/STORE.md
+++ b/packaging/snap/STORE.md
@@ -3,9 +3,9 @@
 ## Setup Steps
 
 1. ~~Register the `proton-drive` snap name at https://snapcraft.io/register-snap~~ **Done**
-2. Export Snap Store credentials: `snapcraft export-login --`
-3. Add `SNAPCRAFT_STORE_CREDENTIALS` as a GitHub Actions secret
-4. Add `publish-snap.yml` workflow to upload snaps on release
+2. ~~Export Snap Store credentials: `snapcraft export-login -`~~ **Done**
+3. ~~Add `SNAPCRAFT_STORE_CREDENTIALS` as a GitHub Actions secret~~ **Done**
+4. ~~Add `publish-snap.yml` workflow to upload snaps on release~~ **Done**
 5. Test end-to-end: tag push → build → upload → `snap install proton-drive`
 
 ## Confinement
@@ -58,4 +58,7 @@ respectively. No patch changes are needed for Snap Store publishing.
 - `packaging/snap/snapcraft.yaml` uses `confinement: strict` with
   `removable-media` plug
 - Snap name `proton-drive` registered on the Snap Store
-- No Snap Store publishing pipeline exists yet
+- Snap Store publishing pipeline: `publish-snap.yml` uploads snaps on
+  release using `SNAPCRAFT_STORE_CREDENTIALS` secret
+- End-to-end test (tag push -> build -> upload -> `snap install
+  proton-drive`) is tracked in issue #83


### PR DESCRIPTION
Issue: #83
Refs: #1, #19

## Changes

### [`.github/workflows/publish-flatpak.yml`](https://github.com/DonnieDice/protondrive-linux/pull/89/files#diff-5bfb6b472f851b18e09042f5d16d0c8cc9fba534) — new Flathub publish workflow
- Triggers on release or manual dispatch
- Resolves WebClients commit and SHA256, source tag commit
- Clones `flathub/com.proton.drive` via SSH, updates manifest with new version/runtime/checksums
- Pushes updated manifest and metainfo to Flathub repo
- Requires `FLATHUB_SSH_PRIVATE_KEY` secret and initial Flathub submission PR

### [`.github/workflows/build-flatpak.yml`](https://github.com/DonnieDice/protondrive-linux/pull/89/files#diff-900bef389f473669bd283245c1f230ba904d3a8b) — fix GNOME 50 Flatpak manifest
- Changed `--socket=x11` to `--socket=fallback-x11` (Flathub requirement)
- Removed `--filesystem=home` and `--system-talk-name=org.freedesktop.NetworkManager` (overly broad)
- Added `--filesystem=xdg-documents` for future file sync
- Fixed wrapper `GDK_GL=software` to `GDK_GL=disable` (matches GNOME 50 patch)
- Added metainfo XML installation to the manifest

### [`.github/workflows/build-flatpak.gnome49.yml`](https://github.com/DonnieDice/protondrive-linux/pull/89/files#diff-8615c88569f56b35939a9dc7f266802171ca7595) — fix GNOME 49 Flatpak manifest
- Same finish-args fixes as GNOME 50
- Kept `GDK_GL=software` (matches GNOME 49 patch)
- Added metainfo XML installation to the manifest

### [`.github/workflows/release.yml`](https://github.com/DonnieDice/protondrive-linux/pull/89/files#diff-903b4d8d6e014833cea998137cb1ea742467d416) — update release notes
- Added Flathub install instruction (`flatpak install flathub com.proton.drive`)
- Added "also on Flathub" note to Flatpak rows in downloads table

### [`packaging/com.proton.drive.yml`](https://github.com/DonnieDice/protondrive-linux/pull/89/files#diff-22e768f9a5c483886ee8a82170dda21a8b8708e3) — update Flathub reference manifest
- Replaced pinned commit with `PLACEHOLDER` markers (versioned at publish time)
- Added WebClients archive source with placeholder SHA256
- Added full WebKitGTK env vars in wrapper (DMABUF, compositing, sandbox, GDK_GL=disable)
- Removed `type: file` local source for metainfo (installed from git source)

### [`packaging/compatibility-map.yml`](https://github.com/DonnieDice/protondrive-linux/pull/89/files#diff-af9e66eb4383b374c9bc5bc39f55a6b7bae6ae9b) — add Flathub publish metadata
- Added `publish_flatpak` to `ci_workflows` section
- Added `publish_workflow` and `flathub_app_id` to both Flatpak entries

### [`packaging/snap/STORE.md`](https://github.com/DonnieDice/protondrive-linux/pull/89/files#diff-ebe6df944fa0b8b327c315123ddc90f5fba3661c) — fix stale "no pipeline" note
- Updated Current State to reflect that `publish-snap.yml` now exists
- Marked setup steps 2-4 as completed
- Added issue #83 reference for remaining end-to-end test

### [`packaging/FLATHUB.md`](https://github.com/DonnieDice/protondrive-linux/pull/89/files#diff-4dfeb063309891fabae9c0b4ecc46f4db710d0fb) — new Flathub distribution doc
- Documents the full Flathub submission and setup process
- Lists finish-args rationale, runtime settings, and current state

### [`docs/packaging.md`](https://github.com/DonnieDice/protondrive-linux/pull/89/files#diff-77b81f23e9988a363df5adc258f4dbf9ab418895) — add publishing workflows section
- Added Flathub distribution URL and publish workflow reference
- Added Snap Store publish workflow reference
- Added AUR publish workflow reference
- Added new Publishing Workflows table with secrets and targets
- Added publish workflow secrets check to release checklist

### [`docs/release-checklist.md`](https://github.com/DonnieDice/protondrive-linux/pull/89/files#diff-27453f3be41cb7e6977a2e8e098f5a2056cc0f78) — add publish secret checks
- Added checklist items for `AUR_SSH_PRIVATE_KEY`, `SNAPCRAFT_STORE_CREDENTIALS`, and `FLATHUB_SSH_PRIVATE_KEY`
- Added Flathub initial submission PR requirement
