### PR TITLE
(#93) Fix flatpak YAML generation printf indentation

### DIFF
--- a/.github/workflows/build-flatpak.gnome49.yml
+++ b/.github/workflows/build-flatpak.gnome49.yml
@@ -148,13 +148,12 @@ jobs:
             '  - --share=ipc' \
             '  - --socket=fallback-x11' \
             '  - --socket=wayland' \
-          '- --socket=wayland' \
-          '- --socket=pulseaudio' \
-          '- --device=dri' \
-          '- --filesystem=xdg-download' \
-          '- --filesystem=xdg-documents' \
-          '- --talk-name=org.freedesktop.secrets' \
-          '- --talk-name=org.freedesktop.Notifications' \
+            '  - --socket=pulseaudio' \
+            '  - --device=dri' \
+            '  - --filesystem=xdg-download' \
+            '  - --filesystem=xdg-documents' \
+            '  - --talk-name=org.freedesktop.secrets' \
+            '  - --talk-name=org.freedesktop.Notifications' \
           'modules:' \
           '- name: proton-drive' \
           '  buildsystem: simple' \

--- a/.github/workflows/build-flatpak.gnome49.yml
+++ b/.github/workflows/build-flatpak.gnome49.yml
@@ -154,22 +154,22 @@ jobs:
             '  - --filesystem=xdg-documents' \
             '  - --talk-name=org.freedesktop.secrets' \
             '  - --talk-name=org.freedesktop.Notifications' \
-          'modules:' \
-          '- name: proton-drive' \
-          '  buildsystem: simple' \
-          '  sources:' \
-          '  - type: dir' \
-          '    path: flatpak-staging' \
-          '  build-commands:' \
-          '  - install -Dm755 proton-drive-bin /app/bin/proton-drive-bin' \
-          '  - install -Dm755 proton-drive /app/bin/proton-drive' \
-          '  - install -Dm644 icons/32x32.png /app/share/icons/hicolor/32x32/apps/com.proton.drive.png' \
-          '  - install -Dm644 icons/128x128.png /app/share/icons/hicolor/128x128/apps/com.proton.drive.png' \
-          '  - install -Dm644 icons/128x128@2x.png /app/share/icons/hicolor/256x256/apps/com.proton.drive.png' \
-          '  - install -Dm644 icons/proton-drive.svg /app/share/icons/hicolor/scalable/apps/com.proton.drive.svg' \
-          '  - install -Dm644 com.proton.drive.desktop /app/share/applications/com.proton.drive.desktop' \
-          '  - install -Dm644 com.proton.drive.metainfo.xml /app/share/metainfo/com.proton.drive.metainfo.xml' \
-          > com.proton.drive.yml
+            'modules:' \
+            '- name: proton-drive' \
+            '  buildsystem: simple' \
+            '  sources:' \
+            '  - type: dir' \
+            '    path: flatpak-staging' \
+            '  build-commands:' \
+            '  - install -Dm755 proton-drive-bin /app/bin/proton-drive-bin' \
+            '  - install -Dm755 proton-drive /app/bin/proton-drive' \
+            '  - install -Dm644 icons/32x32.png /app/share/icons/hicolor/32x32/apps/com.proton.drive.png' \
+            '  - install -Dm644 icons/128x128.png /app/share/icons/hicolor/128x128/apps/com.proton.drive.png' \
+            '  - install -Dm644 icons/128x128@2x.png /app/share/icons/hicolor/256x256/apps/com.proton.drive.png' \
+            '  - install -Dm644 icons/proton-drive.svg /app/share/icons/hicolor/scalable/apps/com.proton.drive.svg' \
+            '  - install -Dm644 com.proton.drive.desktop /app/share/applications/com.proton.drive.desktop' \
+            '  - install -Dm644 com.proton.drive.metainfo.xml /app/share/metainfo/com.proton.drive.metainfo.xml' \
+            > com.proton.drive.yml
 
           rm -rf build-dir repo
           flatpak-builder --user --force-clean --repo=repo build-dir com.proton.drive.yml

--- a/.github/workflows/build-flatpak.yml
+++ b/.github/workflows/build-flatpak.yml
@@ -149,13 +149,12 @@ jobs:
             '  - --share=ipc' \
             '  - --socket=fallback-x11' \
             '  - --socket=wayland' \
-          '- --socket=wayland' \
-          '- --socket=pulseaudio' \
-          '- --device=dri' \
-          '- --filesystem=xdg-download' \
-          '- --filesystem=xdg-documents' \
-          '- --talk-name=org.freedesktop.secrets' \
-          '- --talk-name=org.freedesktop.Notifications' \
+            '  - --socket=pulseaudio' \
+            '  - --device=dri' \
+            '  - --filesystem=xdg-download' \
+            '  - --filesystem=xdg-documents' \
+            '  - --talk-name=org.freedesktop.secrets' \
+            '  - --talk-name=org.freedesktop.Notifications' \
           'modules:' \
           '- name: proton-drive' \
           '  buildsystem: simple' \

--- a/.github/workflows/build-flatpak.yml
+++ b/.github/workflows/build-flatpak.yml
@@ -155,22 +155,22 @@ jobs:
             '  - --filesystem=xdg-documents' \
             '  - --talk-name=org.freedesktop.secrets' \
             '  - --talk-name=org.freedesktop.Notifications' \
-          'modules:' \
-          '- name: proton-drive' \
-          '  buildsystem: simple' \
-          '  sources:' \
-          '  - type: dir' \
-          '    path: flatpak-staging' \
-          '  build-commands:' \
-          '  - install -Dm755 proton-drive-bin /app/bin/proton-drive-bin' \
-          '  - install -Dm755 proton-drive /app/bin/proton-drive' \
-          '  - install -Dm644 icons/32x32.png /app/share/icons/hicolor/32x32/apps/com.proton.drive.png' \
-          '  - install -Dm644 icons/128x128.png /app/share/icons/hicolor/128x128/apps/com.proton.drive.png' \
-          '  - install -Dm644 icons/128x128@2x.png /app/share/icons/hicolor/256x256/apps/com.proton.drive.png' \
-          '  - install -Dm644 icons/proton-drive.svg /app/share/icons/hicolor/scalable/apps/com.proton.drive.svg' \
-          '  - install -Dm644 com.proton.drive.desktop /app/share/applications/com.proton.drive.desktop' \
-          '  - install -Dm644 com.proton.drive.metainfo.xml /app/share/metainfo/com.proton.drive.metainfo.xml' \
-          > com.proton.drive.yml
+            'modules:' \
+            '- name: proton-drive' \
+            '  buildsystem: simple' \
+            '  sources:' \
+            '  - type: dir' \
+            '    path: flatpak-staging' \
+            '  build-commands:' \
+            '  - install -Dm755 proton-drive-bin /app/bin/proton-drive-bin' \
+            '  - install -Dm755 proton-drive /app/bin/proton-drive' \
+            '  - install -Dm644 icons/32x32.png /app/share/icons/hicolor/32x32/apps/com.proton.drive.png' \
+            '  - install -Dm644 icons/128x128.png /app/share/icons/hicolor/128x128/apps/com.proton.drive.png' \
+            '  - install -Dm644 icons/128x128@2x.png /app/share/icons/hicolor/256x256/apps/com.proton.drive.png' \
+            '  - install -Dm644 icons/proton-drive.svg /app/share/icons/hicolor/scalable/apps/com.proton.drive.svg' \
+            '  - install -Dm644 com.proton.drive.desktop /app/share/applications/com.proton.drive.desktop' \
+            '  - install -Dm644 com.proton.drive.metainfo.xml /app/share/metainfo/com.proton.drive.metainfo.xml' \
+            > com.proton.drive.yml
 
           rm -rf build-dir repo
           flatpak-builder --user --force-clean --repo=repo build-dir com.proton.drive.yml


### PR DESCRIPTION
Issue: #92

## Changes

### [.github/workflows/build-flatpak.yml](https://github.com/DonnieDice/protondrive-linux/pull/93/files#diff-d2a0c72488b0df8b6d6d02d4d5d8a5001588ab99) — Fixed printf line continuation
- Lines starting from 'modules:' lost their leading indentation in the printf command
- This broke shell line continuation, causing those lines to execute as separate commands instead of printf arguments
- Resulted in truncated/malformed com.proton.drive.yml that flatpak-builder could not parse

### [.github/workflows/build-flatpak.gnome49.yml](https://github.com/DonnieDice/protondrive-linux/pull/93/files#diff-07ae749e09b359490775cf0b3a32045a60505757) — Same fix applied
- Identical printf indentation bug fixed for GNOME 49 workflow