### PR TITLE
(#101) Update PR title numbering docs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,14 +10,15 @@ If this PR is partial work, use `Refs #98` instead.
 ## PR Title Checklist
 
 Your PR title must match: `^\(#\d+\)\s[A-Z].{9,}$`
+After GitHub assigns this PR number, edit the title so the prefix matches it.
 
-- [ ] Starts with the tracked issue number, not the PR number
-- [ ] Uses an uppercase first letter after the issue prefix
-- [ ] Has a descriptive title, e.g. `(#98) Fix BOM encoding corruption`
+- [ ] Starts with this PR's number, not the tracked issue number
+- [ ] Uses an uppercase first letter after the PR prefix
+- [ ] Has a descriptive title, e.g. `(#99) Fix BOM encoding corruption`
 
-**Correct:** `(#98) Fix BOM encoding corruption`
-**Incorrect:** `Fix BOM encoding corruption` (missing issue number)
-**Incorrect:** `(#98) fix BOM encoding corruption` (lowercase start)
+**Correct:** `(#99) Fix BOM encoding corruption`
+**Incorrect:** `Fix BOM encoding corruption` (missing PR number)
+**Incorrect:** `(#99) fix BOM encoding corruption` (lowercase start)
 
 ## Summary
 

--- a/.opencode/agent/protondrive-conventions.md
+++ b/.opencode/agent/protondrive-conventions.md
@@ -45,7 +45,7 @@ mode: primary
 
 Enforce a strict code review and metadata loop before any merge:
 
-1. **Edit Title:** Set PR title to `(#ISSUE-number) Descriptive title`.
+1. **Edit Title:** Set PR title to `(#PR-number) Descriptive title`.
 2. **Links:** Include useful related links in a `## Links` section using
    compact icon bullets.
 3. **Changed Areas:** Use plain repository file paths for changed files.
@@ -68,9 +68,11 @@ Enforce a strict code review and metadata loop before any merge:
 
 ## PR Titles
 
-- Format: `(#ISSUE-number) Descriptive title starting with uppercase`.
-- The number in the PR title is the tracked **issue** number, not the PR number.
-- If there is no issue, create or verify a tracking issue before opening the PR.
+- Format: `(#PR-number) Descriptive title starting with uppercase`.
+- The number in the PR title is the **PR** number, not the tracked issue number.
+- If the PR number is not known yet, create the PR first, then edit the title
+  once GitHub assigns the PR number.
+- Keep the tracked issue in the PR body with `Closes #N` or `Refs #N`.
 - Same regex as commits: `^\(#\d+\)\s[A-Z].{9,}$`.
 - Use tracking issue wording in PR bodies or external docs only, never as a
   self-reference inside the tracked issue body.

--- a/.opencode/agents/conventions.md
+++ b/.opencode/agents/conventions.md
@@ -21,15 +21,17 @@ Commit messages must match CommitCheck regex:
 
 ## PR Titles
 
-PR titles use the tracked issue number at the start:
+PR titles use the PR number at the start:
 
 ```text
-(#ISSUE_NUMBER) Description
+(#PR_NUMBER) Description
 ```
 
-- Example: `(#92) Fix flatpak YAML generation printf indentation`.
+- Example: `(#93) Fix flatpak YAML generation printf indentation`.
 - Must match `^\(#\d+\)\s[A-Z].{9,}$`.
-- The PR title number is the issue number, not the PR number.
+- The PR title number is the PR number, not the tracked issue number.
+- If the PR number is not known yet, create the PR first, then edit the title
+  once GitHub assigns the PR number.
 - If there is no tracking issue, create or verify one before opening the PR.
 
 ## Issue And PR Links
@@ -39,7 +41,7 @@ Numbers and links are required, but they must be stable and real.
 | Context | Required reference | Example |
 |---------|--------------------|---------|
 | Commit message | Issue number | `(#92) Fix workflow YAML indentation` |
-| PR title | Issue number | `(#92) Fix workflow YAML indentation` |
+| PR title | PR number | `(#93) Fix workflow YAML indentation` |
 | PR body | Closing issue plus icon links | `Closes #92` and `- 🔗 Related: #91` |
 | Issue body | Related issue/PR URLs when known | `https://github.com/DonnieDice/protondrive-linux/pull/99` |
 
@@ -141,7 +143,7 @@ No intermediate branches. All feature branches merge directly to `main`.
 1. Fetch the latest base.
 2. Create a feature/fix/chore branch from latest `main`.
 3. Make changes and commit with `(#ISSUE) Description`.
-4. Push branch and create PR with `(#ISSUE) Description`.
+4. Push branch, create PR, then edit the title to `(#PR) Description`.
 5. Edit PR body with issue links, PR link, changed paths, and testing.
 6. Wait for CI and review bot feedback before merging.
 7. After merge, delete both remote and local branches.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -203,19 +203,21 @@ All PR titles must match the CommitCheck regex: `^\(#\d+\)\s[A-Z].{9,}$`
 
 Rules:
 
-- The number in the PR title is the tracked **issue** number, not the PR number
-- Start with an uppercase letter after the issue prefix
-- Be at least 10 characters long after the issue prefix
-- Put the issue prefix at the start of the title, e.g. `(#42) Title here`
+- The number in the PR title is the **PR** number, not the tracked issue number
+- Start with an uppercase letter after the PR prefix
+- Be at least 10 characters long after the PR prefix
+- Put the PR prefix at the start of the title, e.g. `(#43) Title here`
+- If GitHub has not assigned the PR number yet, create the PR first, then edit
+  the title once the number exists
 
 Examples:
 
-- `(#47) Add Alpine 3.20 APK build target`
-- `(#51) Fix linker flags for musl static linking`
-- `(#38) Update WebClients clone depth in build script`
+- `(#48) Add Alpine 3.20 APK build target`
+- `(#52) Fix linker flags for musl static linking`
+- `(#39) Update WebClients clone depth in build script`
 
 Open an issue before opening a PR when there is no tracked issue yet. This keeps
-commits, PR titles, and closing links aligned from the first push.
+commits and closing links aligned from the first push.
 
 ### Review Bot Feedback
 
@@ -233,7 +235,7 @@ Before merging **any** PR, all automated review bot findings must be addressed:
   prefix when the commit is not a squash-merge PR title.
 - Use the commit body or footer for extra traceability if needed
   (`Refs #123` or `Closes #123`).
-- Use the PR title for the same **issue** number prefix (`(#123) ...`).
+- Use the PR title for the **PR** number prefix (`(#124) ...`).
 - Do not link file diffs or fake PR numbers in commit titles.
 - If there is no issue yet, create one before writing the commit title.
 

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -57,12 +57,14 @@ Open a PR when your branch is ready for review. A PR:
 ### PR Title Format
 
 ```
-(#ISSUE-number) Descriptive title starting with uppercase
+(#PR-number) Descriptive title starting with uppercase
 ```
 
 The PR title must match: `^\(#\d+\)\s[A-Z].{9,}$`
 
-The number in the PR title is the tracked **issue** number, not the PR number.
+The number in the PR title is the **PR** number, not the tracked issue number.
+If GitHub has not assigned the PR number yet, create the PR first, then edit the
+title once the number exists.
 Open an issue first when work does not already have one.
 
 ### Commit Message Format
@@ -113,7 +115,7 @@ paths are stable, and reviewers can use the Files changed tab for exact diffs.
 
 Before any merge, enforce a strict code review and metadata loop:
 
-1. **Edit Title:** Set PR title to `(#ISSUE-number) Descriptive title`
+1. **Edit Title:** Set PR title to `(#PR-number) Descriptive title`
 2. **Issue Link:** Confirm the PR body includes `Closes #N` or `Refs #N`
 3. **Context:** Provide a detailed summary answering **WHY** the changes were made
 4. **CR Feedback:** If a code review requires changes, iterate within the same branch


### PR DESCRIPTION
## Summary

- Update the PR template and agent conventions so PR title prefixes use the PR number.
- Keep tracked issue references in commit messages, branch context, and PR body `Closes #N` / `Refs #N` lines.

## Changed Areas

- `.github/PULL_REQUEST_TEMPLATE.md`
- `.opencode/agent/protondrive-conventions.md`
- `.opencode/agents/conventions.md`
- `docs/CONTRIBUTING.md`
- `docs/workflow.md`

## Testing

- `git diff --check`

Docs-only convention update. No tracking issue.